### PR TITLE
[MINOR] Fix issue template name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Custom issue template
-about: Describe this issue template's purpose here.
+name: Bug report
+about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->

When I wanted to create an issue, I found that only the feature-request template was available

<img width="377" alt="p1" src="https://github.com/TuGraph-family/tugraph-analytics/assets/42756849/3de1df1a-c2fc-4be8-8433-196af1421863">

According to the information, it is found that the templates (bug-report and custom) has the same name

<img width="401" alt="p2" src="https://github.com/TuGraph-family/tugraph-analytics/assets/42756849/9f74dbdc-b3ee-47a7-a2bc-7059e60e63a1">

So it was renamed based on https://github.com/TuGraph-family/tugraph-analytics/commit/f69aa453120890ae42acf487d739f6602f2ce1a7

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
