### PR TITLE
[#20]Instr/IndexOf support BinaryString as input parameter

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/binary/BinaryString.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/binary/BinaryString.java
@@ -226,6 +226,33 @@ public class BinaryString implements Comparable<BinaryString>, Serializable, Kry
         return false;
     }
 
+    public int indexOf(BinaryString v, int start) {
+        if (v.numBytes == 0) {
+            return 0;
+        }
+
+        // locate to the start position.
+        int i = 0; // position in byte
+        int c = 0; // position in character
+        while (i < numBytes && c < start) {
+            i += numBytesForFirstByte(getByte(i));
+            c += 1;
+        }
+
+        do {
+            if (i + v.numBytes > numBytes) {
+                return -1;
+            }
+            if (BinaryOperations.arrayEquals(binaryObject, offset + i, v.binaryObject, v.offset, v.numBytes)) {
+                return c;
+            }
+            i += numBytesForFirstByte(getByte(i));
+            c += 1;
+        } while (i < numBytes);
+
+        return -1;
+    }
+
     public boolean matchAt(final BinaryString s, int pos) {
         if (s.numBytes + pos > numBytes || pos < 0) {
             return false;

--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/binary/BinaryString.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/binary/BinaryString.java
@@ -226,8 +226,8 @@ public class BinaryString implements Comparable<BinaryString>, Serializable, Kry
         return false;
     }
 
-    public int indexOf(BinaryString v, int start) {
-        if (v.numBytes == 0) {
+    public int indexOf(BinaryString s, int start) {
+        if (s.numBytes == 0) {
             return 0;
         }
 
@@ -240,10 +240,10 @@ public class BinaryString implements Comparable<BinaryString>, Serializable, Kry
         }
 
         do {
-            if (i + v.numBytes > numBytes) {
+            if (i + s.numBytes > numBytes) {
                 return -1;
             }
-            if (BinaryOperations.arrayEquals(binaryObject, offset + i, v.binaryObject, v.offset, v.numBytes)) {
+            if (BinaryOperations.arrayEquals(binaryObject, offset + i, s.binaryObject, s.offset, s.numBytes)) {
                 return c;
             }
             i += numBytesForFirstByte(getByte(i));

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/string/IndexOf.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/string/IndexOf.java
@@ -14,11 +14,16 @@
 
 package com.antgroup.geaflow.dsl.udf.table.string;
 
+import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
 
-@Description(name = "index_of", description = "Returns the position of the target string in the string.")
+@Description(name = "index_of", description = "Returns the position of the first occurrence of the target string in the string.")
 public class IndexOf extends UDF {
+
+    public Integer eval(String str, String target) {
+        return eval(str, target, 0);
+    }
 
     public Integer eval(String str, String target, Integer index) {
         if ((str == null) || (target == null) || (index == null)) {
@@ -31,7 +36,18 @@ public class IndexOf extends UDF {
         return str.indexOf(target, fromIndex);
     }
 
-    public Integer eval(String str, String target) {
+    public Integer eval(BinaryString str, BinaryString target) {
         return eval(str, target, 0);
+    }
+
+    public Integer eval(BinaryString str, BinaryString target, Integer index) {
+        if ((str == null) || (target == null) || (index == null)) {
+            return -1;
+        }
+        int fromIndex = index;
+        if (fromIndex < 0) {
+            fromIndex = 0;
+        }
+        return str.indexOf(target, fromIndex);
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/string/Instr.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/string/Instr.java
@@ -14,6 +14,7 @@
 
 package com.antgroup.geaflow.dsl.udf.table.string;
 
+import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
 
@@ -29,6 +30,31 @@ public class Instr extends UDF {
     }
 
     public Long eval(String str, String target, Long from, Long nth) {
+        if (str == null || target == null || from == null || nth == null) {
+            return null;
+        }
+        if (nth <= 0) {
+            return null;
+        }
+        int fromIndex = from.intValue() - 1;
+        if (fromIndex < 0) {
+            return null;
+        }
+        for (int i = 0; i < nth; ++i) {
+            fromIndex = str.indexOf(target, fromIndex) + 1;
+        }
+        return (long) fromIndex;
+    }
+
+    public Long eval(BinaryString str, BinaryString target) {
+        return eval(str, target, 1L, 1L);
+    }
+
+    public Long eval(BinaryString str, BinaryString target, Long from) {
+        return eval(str, target, from, 1L);
+    }
+
+    public Long eval(BinaryString str, BinaryString target, Long from, Long nth) {
         if (str == null || target == null || from == null || nth == null) {
             return null;
         }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/udf/string/UDFInstrTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/udf/string/UDFInstrTest.java
@@ -16,6 +16,7 @@ package com.antgroup.geaflow.dsl.udf.string;
 
 import static org.testng.Assert.assertEquals;
 
+import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.dsl.udf.table.string.Instr;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,30 @@ public class UDFInstrTest {
         assertEquals(2, (long) udf.eval("s.taobao.com", ".", 1L));
 
         assertEquals(0, (long) udf.eval("s.taobao.com", "abc"));
+    }
+
+    @Test
+    public void testBinaryString() {
+
+        Instr udf = new Instr();
+
+        assertEquals(1L, (long) udf.eval(BinaryString.fromString("abc"), BinaryString.fromString("a")));
+
+        assertEquals(3L, (long) udf.eval(BinaryString.fromString("abc"), BinaryString.fromString("c")));
+
+        assertEquals(0L, (long) udf.eval(BinaryString.fromString("abc"), BinaryString.fromString("d")));
+
+        assertEquals(3L, (long) udf.eval(BinaryString.fromString("abc"), BinaryString.fromString("c"), 1L));
+
+        assertEquals(6L, (long) udf.eval(BinaryString.fromString("abcabc"), BinaryString.fromString("c"), 4L));
+
+        assertEquals(2L, (long) udf.eval(BinaryString.fromString("a\u0002abc\u0002c"), BinaryString.fromString("\u0002"), 2L));
+
+        assertEquals(2L, (long) udf.eval(BinaryString.fromString("a\002b\002c"), BinaryString.fromString("\002")));
+
+        assertEquals(9L, (long) udf.eval(BinaryString.fromString("s.taobao.com"), BinaryString.fromString("."), 3L));
+        assertEquals(2, (long) udf.eval(BinaryString.fromString("s.taobao.com"), BinaryString.fromString("."), 1L));
+
+        assertEquals(0, (long) udf.eval(BinaryString.fromString("s.taobao.com"), BinaryString.fromString("abc")));
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/udf/string/UDFStringTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/udf/string/UDFStringTest.java
@@ -87,12 +87,20 @@ public class UDFStringTest {
     @Test
     public void testIndexOf() {
         String string = "ant group";
+        BinaryString binaryString = BinaryString.fromString("ant group");
         IndexOf test = new IndexOf();
         test.open(null);
         assertEquals((int)test.eval(string, "ant"), 0);
         assertEquals((int)test.eval(string, "group", 3), 4);
         assertEquals((int)test.eval(null, "ant"), -1);
         assertEquals((int)test.eval(string, "group", -1), 4);
+
+        assertEquals((int)test.eval(binaryString,  BinaryString.fromString("ant")), 0);
+        assertEquals((int)test.eval(binaryString, BinaryString.fromString("group"), 3), 4);
+        assertEquals((int)test.eval(null, BinaryString.fromString("ant")), -1);
+        assertEquals((int)test.eval(binaryString, BinaryString.fromString("group"), -1), 4);
+
+        assertEquals((int)test.eval(BinaryString.fromString("数据砖头"), BinaryString.fromString("砖"), -1), 2);
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implemented the indexOf function in BinaryString by referencing spark UTF8String. Instr/IndexOf support BinaryString as input parameter.

### How was this PR tested?
- [x] Tests have Added for the changes
- [ ] Production environment verified
