### PR TITLE
[ISSUE-82] Support type registration optimization for Kryo serializer

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/serialize/impl/KryoSerializer.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/serialize/impl/KryoSerializer.java
@@ -111,6 +111,85 @@ public class KryoSerializer implements ISerializer {
                 }
             }
 
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.BinaryRow", 1011);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.DefaultParameterizedPath",
+                "com.antgroup.geaflow.dsl.common.data.impl.DefaultParameterizedPath$DefaultParameterizedPathSerializer", 1012);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.DefaultParameterizedRow",
+                "com.antgroup.geaflow.dsl.common.data.impl.DefaultParameterizedRow$DefaultParameterizedRowSerializer", 1013);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.DefaultPath",
+                "com.antgroup.geaflow.dsl.common.data.impl.DefaultPath$DefaultPathSerializer", 1014);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.DefaultRowKeyWithRequestId",
+                "com.antgroup.geaflow.dsl.common.data.impl.DefaultRowKeyWithRequestId$DefaultRowKeyWithRequestIdSerializer", 1015);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.ObjectRow",
+                "com.antgroup.geaflow.dsl.common.data.impl.ObjectRow$ObjectRowSerializer", 1016);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.ObjectRowKey",
+                "com.antgroup.geaflow.dsl.common.data.impl.ObjectRowKey$ObjectRowKeySerializer", 1017);
+
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.BinaryStringEdge", 1018);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.BinaryStringTsEdge", 1019);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.BinaryStringVertex", 1020);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.DoubleEdge", 1021);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.DoubleTsEdge", 1022);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.DoubleVertex", 1023);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.IntEdge", 1024);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.IntTsEdge", 1025);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.IntVertex", 1026);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.LongEdge", 1027);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.LongTsEdge", 1028);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.LongVertex", 1029);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.ObjectEdge", 1030);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.ObjectTsEdge", 1031);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.types.ObjectVertex", 1032);
+
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignEdge",
+                "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignEdge$FieldAlignEdgeSerializer", 1033);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignPath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignPath$FieldAlignPathSerializer", 1034);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignVertex",
+                "com.antgroup.geaflow.dsl.runtime.traversal.data.FieldAlignVertex$FieldAlignVertexSerializer", 1035);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.data.IdOnlyVertex", 1036);
+
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.ParameterizedRow", 1037);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.Path", 1038);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.Row", 1039);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.RowEdge", 1040);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.RowKey", 1041);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.RowKeyWithRequestId", 1042);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.RowVertex", 1043);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.common.data.impl.ParameterizedPath", 1044);
+
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.EODMessage",
+                "com.antgroup.geaflow.dsl.runtime.traversal.message.EODMessage$EODMessageSerializer", 1045);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.IPathMessage", 1046);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.JoinPathMessage",
+                "com.antgroup.geaflow.dsl.runtime.traversal.message.JoinPathMessage$JoinPathMessageSerializer", 1047);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.KeyGroupMessage", 1048);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.KeyGroupMessageImpl",
+                "com.antgroup.geaflow.dsl.runtime.traversal.message.KeyGroupMessageImpl$KeyGroupMessageImplSerializer", 1049);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.ParameterRequestMessage",
+                "com.antgroup.geaflow.dsl.runtime.traversal.message.ParameterRequestMessage$ParameterRequestMessageSerializer", 1050);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.RequestIsolationMessage", 1051);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.ReturnMessage", 1052);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.message.ReturnMessageImpl",
+                "com.antgroup.geaflow.dsl.runtime.traversal.message.ReturnMessageImpl$ReturnMessageImplSerializer", 1053);
+
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.AbstractSingleTreePath", 1054);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.AbstractTreePath", 1055);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.EdgeTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.EdgeTreePath$EdgeTreePathSerializer", 1056);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.EmptyTreePath", 1057);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath", 1058);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.ParameterizedTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.ParameterizedTreePath$ParameterizedTreePathSerializer", 1059);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.SourceEdgeTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.SourceEdgeTreePath$SourceEdgeTreePathSerializer", 1060);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.SourceVertexTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.SourceVertexTreePath$SourceVertexTreePathSerializer", 1061);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.UnionTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.UnionTreePath$UnionTreePathSerializer", 1062);
+            registerClass(kryo, "com.antgroup.geaflow.dsl.runtime.traversal.path.VertexTreePath",
+                "com.antgroup.geaflow.dsl.runtime.traversal.path.VertexTreePath$VertexTreePathSerializer", 1063);
+
             return kryo;
         }
     };
@@ -120,6 +199,27 @@ public class KryoSerializer implements ISerializer {
             LOGGER.info("register class:{} id:{}", className, kryoId);
             Class<?> clazz = ClassUtil.classForName(className);
             kryo.register(clazz, kryoId);
+        } catch (GeaflowRuntimeException e) {
+            if (e.getCause() instanceof ClassNotFoundException) {
+                LOGGER.warn("class not found: {} skip register id:{}", className, kryoId);
+            }
+        } catch (Throwable e) {
+            LOGGER.error("error in register class: {} to kryo.", className);
+            throw new GeaflowRuntimeException(e);
+        }
+    }
+
+    private void registerClass(Kryo kryo, String className, String serializerClassName, int kryoId) {
+        try {
+            LOGGER.info("register class:{} id:{}", className, kryoId);
+            Class<?> clazz = ClassUtil.classForName(className);
+            Class<?> serializerClazz = ClassUtil.classForName(serializerClassName);
+            Serializer serializer = (Serializer) serializerClazz.newInstance();
+            kryo.register(clazz, serializer, kryoId);
+        } catch (GeaflowRuntimeException e) {
+            if (e.getCause() instanceof ClassNotFoundException) {
+                LOGGER.warn("class not found: {} skip register id:{}", className, kryoId);
+            }
         } catch (Throwable e) {
             LOGGER.error("error in register class: {} to kryo.", className);
             throw new GeaflowRuntimeException(e);

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/BinaryRow.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/BinaryRow.java
@@ -26,9 +26,13 @@ import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.binary.FieldReaderFactory;
 import com.antgroup.geaflow.dsl.common.binary.FieldReaderFactory.PropertyFieldReader;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 
-public class BinaryRow implements Row {
+public class BinaryRow implements Row, KryoSerializable {
 
     private IBinaryObject binaryObject;
 
@@ -80,4 +84,19 @@ public class BinaryRow implements Row {
     private boolean isNullValue(int index) {
         return isSet(binaryObject, NULL_BIT_OFFSET, index);
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        byte[] bytes = this.binaryObject.toBytes();
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        int length = input.readInt();
+        byte[] bytes = input.readBytes(length);
+        this.binaryObject = HeapBinaryObject.of(bytes);
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultParameterizedPath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultParameterizedPath.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.Path;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Collection;
 import java.util.List;
 
@@ -109,4 +113,34 @@ public class DefaultParameterizedPath implements ParameterizedPath {
     public void setId(long id) {
         basePath.setId(id);
     }
+
+    public static class DefaultParameterizedPathSerializer extends Serializer<DefaultParameterizedPath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, DefaultParameterizedPath object) {
+            kryo.writeClassAndObject(output, object.basePath);
+            kryo.writeClassAndObject(output, object.getRequestId());
+            kryo.writeClassAndObject(output, object.getParameter());
+            kryo.writeClassAndObject(output, object.getSystemVariables());
+        }
+
+        @Override
+        public DefaultParameterizedPath read(Kryo kryo, Input input, Class<DefaultParameterizedPath> aClass) {
+            Path basePath = (Path) kryo.readClassAndObject(input);
+            Object requestId = kryo.readClassAndObject(input);
+            Row parameterRow = (Row) kryo.readClassAndObject(input);
+            Row systemVariableRow = (Row) kryo.readClassAndObject(input);
+            return new DefaultParameterizedPath(basePath, requestId, parameterRow, systemVariableRow);
+        }
+
+        @Override
+        public DefaultParameterizedPath copy(Kryo kryo, DefaultParameterizedPath original) {
+            Path basePath = kryo.copy(original.basePath);
+            Object requestId = kryo.copy(original.getRequestId());
+            Row parameterRow = kryo.copy(original.getParameter());
+            Row systemVariableRow = kryo.copy(original.getSystemVariables());
+            return new DefaultParameterizedPath(basePath, requestId, parameterRow, systemVariableRow);
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultParameterizedRow.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultParameterizedRow.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.ParameterizedRow;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
 public class DefaultParameterizedRow implements ParameterizedRow {
 
@@ -58,4 +62,34 @@ public class DefaultParameterizedRow implements ParameterizedRow {
     public Object getRequestId() {
         return requestId;
     }
+
+    public static class DefaultParameterizedRowSerializer extends Serializer<DefaultParameterizedRow> {
+
+        @Override
+        public void write(Kryo kryo, Output output, DefaultParameterizedRow object) {
+            kryo.writeClassAndObject(output, object.baseRow);
+            kryo.writeClassAndObject(output, object.getRequestId());
+            kryo.writeClassAndObject(output, object.getParameter());
+            kryo.writeClassAndObject(output, object.getSystemVariables());
+        }
+
+        @Override
+        public DefaultParameterizedRow read(Kryo kryo, Input input, Class<DefaultParameterizedRow> aClass) {
+            Row baseRow = (Row) kryo.readClassAndObject(input);
+            Object requestId = kryo.readClassAndObject(input);
+            Row parameterRow = (Row) kryo.readClassAndObject(input);
+            Row systemVariableRow = (Row) kryo.readClassAndObject(input);
+            return new DefaultParameterizedRow(baseRow, requestId, parameterRow, systemVariableRow);
+        }
+
+        @Override
+        public DefaultParameterizedRow copy(Kryo kryo, DefaultParameterizedRow original) {
+            Row baseRow = kryo.copy(original.baseRow);
+            Object requestId = kryo.copy(original.getRequestId());
+            Row parameterRow = kryo.copy(original.getParameter());
+            Row systemVariableRow = kryo.copy(original.getSystemVariables());
+            return new DefaultParameterizedRow(baseRow, requestId, parameterRow, systemVariableRow);
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultPath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultPath.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.Path;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -113,5 +117,35 @@ public class DefaultPath implements Path {
     @Override
     public void setId(long id) {
         this.id = id;
+    }
+
+    public static class DefaultPathSerializer extends Serializer<DefaultPath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, DefaultPath defaultPath) {
+            output.writeInt(defaultPath.getPathNodes().size());
+            for (Row pathNode : defaultPath.getPathNodes()) {
+                kryo.writeClassAndObject(output, pathNode);
+            }
+        }
+
+        @Override
+        public DefaultPath read(Kryo kryo, Input input, Class<DefaultPath> aClass) {
+            int size = input.readInt();
+            List<Row> pathNodes = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                pathNodes.add((Row) kryo.readClassAndObject(input));
+            }
+            return new DefaultPath(pathNodes);
+        }
+
+        @Override
+        public DefaultPath copy(Kryo kryo, DefaultPath original) {
+            List<Row> pathNodes = new ArrayList<>(original.getPathNodes().size());
+            for (Row pathNode : original.getPathNodes()) {
+                pathNodes.add(kryo.copy(pathNode));
+            }
+            return new DefaultPath(pathNodes);
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultRowKeyWithRequestId.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/DefaultRowKeyWithRequestId.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.RowKey;
 import com.antgroup.geaflow.dsl.common.data.RowKeyWithRequestId;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 
 public class DefaultRowKeyWithRequestId implements RowKeyWithRequestId {
@@ -61,4 +65,26 @@ public class DefaultRowKeyWithRequestId implements RowKeyWithRequestId {
     public int hashCode() {
         return Objects.hash(requestId, rowKey);
     }
+
+    public static class DefaultRowKeyWithRequestIdSerializer extends Serializer<DefaultRowKeyWithRequestId> {
+
+        @Override
+        public void write(Kryo kryo, Output output, DefaultRowKeyWithRequestId object) {
+            kryo.writeClassAndObject(output, object.getRequestId());
+            kryo.writeClassAndObject(output, object.rowKey);
+        }
+
+        @Override
+        public DefaultRowKeyWithRequestId read(Kryo kryo, Input input, Class<DefaultRowKeyWithRequestId> aClass) {
+            Object requestId = kryo.readClassAndObject(input);
+            RowKey rowKey = (RowKey) kryo.readClassAndObject(input);
+            return new DefaultRowKeyWithRequestId(requestId, rowKey);
+        }
+
+        @Override
+        public DefaultRowKeyWithRequestId copy(Kryo kryo, DefaultRowKeyWithRequestId original) {
+            return new DefaultRowKeyWithRequestId(original.requestId, original.rowKey);
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/ObjectRow.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/ObjectRow.java
@@ -16,6 +16,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Arrays;
 
 public class ObjectRow implements Row {
@@ -55,5 +59,31 @@ public class ObjectRow implements Row {
     @Override
     public int hashCode() {
         return Arrays.hashCode(fields);
+    }
+
+    public static class ObjectRowSerializer extends Serializer<ObjectRow> {
+
+        @Override
+        public void write(Kryo kryo, Output output, ObjectRow objectRow) {
+            output.writeInt(objectRow.fields.length);
+            for (Object field : objectRow.fields) {
+                kryo.writeClassAndObject(output, field);
+            }
+        }
+
+        @Override
+        public ObjectRow read(Kryo kryo, Input input, Class<ObjectRow> aClass) {
+            int size = input.readInt();
+            Object[] fields = new Object[size];
+            for (int i = 0; i < size; i++) {
+                fields[i] = kryo.readClassAndObject(input);
+            }
+            return ObjectRow.create(fields);
+        }
+
+        @Override
+        public ObjectRow copy(Kryo kryo, ObjectRow original) {
+            return ObjectRow.create(original.fields);
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/ObjectRowKey.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/ObjectRowKey.java
@@ -16,6 +16,10 @@ package com.antgroup.geaflow.dsl.common.data.impl;
 
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.RowKey;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -63,5 +67,31 @@ public class ObjectRowKey implements RowKey {
         return "ObjectRowKey{"
             + "keys=" + Arrays.toString(keys)
             + '}';
+    }
+
+    public static class ObjectRowKeySerializer extends Serializer<ObjectRowKey> {
+
+        @Override
+        public void write(Kryo kryo, Output output, ObjectRowKey objectRowKey) {
+            output.writeInt(objectRowKey.getKeys().length);
+            for (Object key : objectRowKey.getKeys()) {
+                kryo.writeClassAndObject(output, key);
+            }
+        }
+
+        @Override
+        public ObjectRowKey read(Kryo kryo, Input input, Class<ObjectRowKey> aClass) {
+            int size = input.readInt();
+            Object[] keys = new Object[size];
+            for (int i = 0; i < size; i++) {
+                keys[i] = kryo.readClassAndObject(input);
+            }
+            return new ObjectRowKey(keys);
+        }
+
+        @Override
+        public ObjectRowKey copy(Kryo kryo, ObjectRowKey original) {
+            return new ObjectRowKey(original.getKeys());
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/LongVertex.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/LongVertex.java
@@ -22,10 +22,14 @@ import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
 import com.antgroup.geaflow.dsl.common.types.VertexType;
 import com.antgroup.geaflow.dsl.common.util.BinaryUtil;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class LongVertex implements RowVertex {
+public class LongVertex implements RowVertex, KryoSerializable {
 
     public static final Supplier<LongVertex> CONSTRUCTOR = new Constructor();
 
@@ -157,4 +161,24 @@ public class LongVertex implements RowVertex {
             return new LongVertex();
         }
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        // serialize id, label and value
+        output.writeLong(this.id);
+        kryo.writeClassAndObject(output, this.getBinaryLabel());
+        kryo.writeClassAndObject(output, this.getValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        // deserialize id, label and value
+        long id = input.readLong();
+        BinaryString label = (BinaryString) kryo.readClassAndObject(input);
+        Row value = (Row) kryo.readClassAndObject(input);
+        this.id = id;
+        this.setValue(value);
+        this.setBinaryLabel(label);
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectEdge.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectEdge.java
@@ -21,10 +21,14 @@ import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.types.EdgeType;
 import com.antgroup.geaflow.dsl.common.util.BinaryUtil;
 import com.antgroup.geaflow.model.graph.edge.EdgeDirection;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class ObjectEdge implements RowEdge {
+public class ObjectEdge implements RowEdge, KryoSerializable {
 
     public static final Supplier<ObjectEdge> CONSTRUCTOR = new Constructor();
 
@@ -189,4 +193,30 @@ public class ObjectEdge implements RowEdge {
             return new ObjectEdge();
         }
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        // serialize srcId, targetId, direction, label and value
+        kryo.writeClassAndObject(output, this.getSrcId());
+        kryo.writeClassAndObject(output, this.getTargetId());
+        kryo.writeClassAndObject(output, this.getDirect());
+        kryo.writeClassAndObject(output, this.getBinaryLabel());
+        kryo.writeClassAndObject(output, this.getValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        // deserialize srcId, targetId, direction, label and value
+        Object srcId = kryo.readClassAndObject(input);
+        this.srcId = srcId;
+        Object targetId = kryo.readClassAndObject(input);
+        this.targetId = targetId;
+        EdgeDirection direction = (EdgeDirection) kryo.readClassAndObject(input);
+        this.setDirect(direction);
+        BinaryString label = (BinaryString) kryo.readClassAndObject(input);
+        this.setBinaryLabel(label);
+        Row value = (Row) kryo.readClassAndObject(input);
+        this.setValue(value);
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectTsEdge.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectTsEdge.java
@@ -14,16 +14,22 @@
 
 package com.antgroup.geaflow.dsl.common.data.impl.types;
 
+import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.Row;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.types.EdgeType;
 import com.antgroup.geaflow.model.graph.IGraphElementWithTimeField;
 import com.antgroup.geaflow.model.graph.edge.EdgeDirection;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class ObjectTsEdge extends ObjectEdge implements IGraphElementWithTimeField {
+public class ObjectTsEdge extends ObjectEdge implements IGraphElementWithTimeField,
+    KryoSerializable {
 
     public static final Supplier<ObjectTsEdge> CONSTRUCTOR = new Constructor();
 
@@ -134,4 +140,33 @@ public class ObjectTsEdge extends ObjectEdge implements IGraphElementWithTimeFie
             return new ObjectTsEdge();
         }
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        // serialize srcId, targetId, direction, label, value and time
+        kryo.writeClassAndObject(output, this.getSrcId());
+        kryo.writeClassAndObject(output, this.getTargetId());
+        kryo.writeClassAndObject(output, this.getDirect());
+        kryo.writeClassAndObject(output, this.getBinaryLabel());
+        kryo.writeClassAndObject(output, this.getValue());
+        output.writeLong(this.getTime());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        // deserialize srcId, targetId, direction, label, value and time
+        Object srcId = kryo.readClassAndObject(input);
+        Object targetId = kryo.readClassAndObject(input);
+        EdgeDirection direction = (EdgeDirection) kryo.readClassAndObject(input);
+        BinaryString label = (BinaryString) kryo.readClassAndObject(input);
+        Row value = (Row) kryo.readClassAndObject(input);
+        long time = input.readLong();
+        this.setSrcId(srcId);
+        this.setTargetId(targetId);
+        this.setValue(value);
+        this.setBinaryLabel(label);
+        this.setDirect(direction);
+        this.setTime(time);
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectVertex.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/data/impl/types/ObjectVertex.java
@@ -22,10 +22,14 @@ import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
 import com.antgroup.geaflow.dsl.common.types.VertexType;
 import com.antgroup.geaflow.dsl.common.util.BinaryUtil;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class ObjectVertex implements RowVertex {
+public class ObjectVertex implements RowVertex, KryoSerializable {
 
     public static final Supplier<ObjectVertex> CONSTRUCTOR = new Constructor();
 
@@ -96,7 +100,7 @@ public class ObjectVertex implements RowVertex {
         if (id instanceof Comparable) {
             return ((Comparable) id).compareTo(vertex.getId());
         }
-        return ((Integer) getId().hashCode()).compareTo(vertex.getId().hashCode());
+        return Integer.compare(getId().hashCode(), vertex.getId().hashCode());
     }
 
     @Override
@@ -156,4 +160,25 @@ public class ObjectVertex implements RowVertex {
             return new ObjectVertex();
         }
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        // serialize id, label, and value
+        kryo.writeClassAndObject(output, this.getId());
+        kryo.writeClassAndObject(output, this.getBinaryLabel());
+        kryo.writeClassAndObject(output, this.getValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        // deserialize id, label, and value
+        Object id = kryo.readClassAndObject(input);
+        BinaryString label = (BinaryString) kryo.readClassAndObject(input);
+        Row value = (Row) kryo.readClassAndObject(input);
+        this.id = id;
+        this.setValue(value);
+        this.setBinaryLabel(label);
+    }
+
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryClient.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryClient.java
@@ -107,6 +107,7 @@ public class QueryClient implements QueryCompiler {
         QueryContext queryContext = QueryContext.builder()
             .setEngineContext(engineContext)
             .setCompile(true)
+            .setTraversalParallelism(-1)
             .build();
         queryContext.putConfigParallelism(context.getParallelisms());
         executeQuery(script, queryContext);

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryContext.java
@@ -80,6 +80,8 @@ public class QueryContext {
 
     private long opNameCounter = 0L;
 
+    private int traversalParallelism = -1;
+
     private final Map<String, String> setOptions = new HashMap<>();
 
     private final Map<String, PWindowStream<RowVertex>> graphVertices = new HashMap<>();
@@ -329,11 +331,21 @@ public class QueryContext {
         return new Configuration(globalConf);
     }
 
+    public void setTraversalParallelism(int traversalParallelism) {
+        this.traversalParallelism = traversalParallelism;
+    }
+
+    public int getTraversalParallelism() {
+        return this.traversalParallelism;
+    }
+
     public static class QueryContextBuilder {
 
         private QueryEngine engineContext;
 
         private boolean isCompile;
+
+        private int traversalParallelism = -1;
 
         public QueryContextBuilder setEngineContext(QueryEngine engineContext) {
             this.engineContext = engineContext;
@@ -345,8 +357,15 @@ public class QueryContext {
             return this;
         }
 
+        public QueryContextBuilder setTraversalParallelism(int traversalParallelism) {
+            this.traversalParallelism = traversalParallelism;
+            return this;
+        }
+
         public QueryContext build() {
-            return new QueryContext(engineContext, isCompile);
+            QueryContext context = new QueryContext(engineContext, isCompile);
+            context.setTraversalParallelism(traversalParallelism);
+            return context;
         }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/command/CreateGraphCommand.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/command/CreateGraphCommand.java
@@ -14,14 +14,13 @@
 
 package com.antgroup.geaflow.dsl.runtime.command;
 
-import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.dsl.calcite.EdgeRecordType;
 import com.antgroup.geaflow.dsl.calcite.VertexRecordType;
-import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
 import com.antgroup.geaflow.dsl.common.types.GraphSchema;
 import com.antgroup.geaflow.dsl.planner.GQLContext;
 import com.antgroup.geaflow.dsl.runtime.QueryContext;
 import com.antgroup.geaflow.dsl.runtime.QueryResult;
+import com.antgroup.geaflow.dsl.runtime.util.QueryUtil;
 import com.antgroup.geaflow.dsl.schema.GeaFlowGraph;
 import com.antgroup.geaflow.dsl.schema.GeaFlowGraph.EdgeTable;
 import com.antgroup.geaflow.dsl.schema.GeaFlowGraph.GraphElementTable;
@@ -30,8 +29,6 @@ import com.antgroup.geaflow.dsl.schema.GeaFlowTable;
 import com.antgroup.geaflow.dsl.sqlnode.SqlCreateGraph;
 import com.antgroup.geaflow.dsl.sqlnode.SqlEdgeUsing;
 import com.antgroup.geaflow.dsl.sqlnode.SqlVertexUsing;
-import com.antgroup.geaflow.view.meta.ViewMetaBookKeeper;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,16 +69,7 @@ public class CreateGraphCommand implements IQueryCommand {
 
     private void processUsing(GeaFlowGraph graph, QueryContext context) {
         //Graph first time creation will trigger insert operations
-        boolean graphExists;
-        try {
-            Configuration globalConfig = graph.getConfigWithGlobal(context.getGlobalConf());
-            ViewMetaBookKeeper keeper = new ViewMetaBookKeeper(graph.getUniqueName(), globalConfig);
-            long lastCheckPointId = keeper.getLatestViewVersion(graph.getUniqueName());
-            graphExists = lastCheckPointId >= 0;
-        } catch (IOException e) {
-            throw new GeaFlowDSLException(e);
-        }
-        if (!graphExists) {
+        if (!QueryUtil.isGraphExists(graph, graph.getConfigWithGlobal(context.getGlobalConf()))) {
             //Convert graph construction using tables to equivalent insert statement
             Map<String, String> vertexEdgeName2UsingTableNameMap = graph.getUsingTables();
             List<GraphElementTable> graphElements = new ArrayList<>(graph.getVertexTables());

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GQLPipeLine.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GQLPipeLine.java
@@ -179,6 +179,7 @@ public class GQLPipeLine {
             QueryContext queryContext = QueryContext.builder()
                 .setEngineContext(engineContext)
                 .setCompile(false)
+                .setTraversalParallelism(-1)
                 .build();
             if (pipelineHook != null) {
                 pipelineHook.beforeExecute(queryClient, queryContext);

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowRuntimeGraph.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowRuntimeGraph.java
@@ -181,8 +181,12 @@ public class GeaFlowRuntimeGraph implements RuntimeGraph {
                     executeDagGroup, maxTraversal);
             }
         }
-
-        responsePWindow = responsePWindow.withParallelism(graph.getShardCount());
+        if (queryContext.getTraversalParallelism() > 0
+            && queryContext.getTraversalParallelism() <= graph.getShardCount()) {
+            responsePWindow = responsePWindow.withParallelism(queryContext.getTraversalParallelism());
+        } else {
+            responsePWindow = responsePWindow.withParallelism(graph.getShardCount());
+        }
         PWindowStream<Row> resultPWindow = responsePWindow.flatMap(new ResponseToRowFunction())
             .withName(queryContext.createOperatorName("TraversalResponseToRow"));
 
@@ -304,7 +308,12 @@ public class GeaFlowRuntimeGraph implements RuntimeGraph {
                     .start();
             }
         }
-        responsePWindow = responsePWindow.withParallelism(graphViewDesc.getShardNum());
+        if (queryContext.getTraversalParallelism() > 0
+            && queryContext.getTraversalParallelism() <= graph.getShardCount()) {
+            responsePWindow = responsePWindow.withParallelism(queryContext.getTraversalParallelism());
+        } else {
+            responsePWindow = responsePWindow.withParallelism(graph.getShardCount());
+        }
         PWindowStream<Row> resultPWindow = responsePWindow.flatMap(
             (FlatMapFunction<ITraversalResponse<Row>, Row>) (value, collector) -> collector.partition(value.getResponse()));
         return new GeaFlowRuntimeTable(queryContext, context, resultPWindow);

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignEdge.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignEdge.java
@@ -23,6 +23,10 @@ import com.antgroup.geaflow.dsl.common.data.impl.types.IntEdge;
 import com.antgroup.geaflow.dsl.common.data.impl.types.LongEdge;
 import com.antgroup.geaflow.model.graph.edge.EdgeDirection;
 import com.antgroup.geaflow.model.graph.edge.IEdge;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -161,4 +165,37 @@ public class FieldAlignEdge implements RowEdge {
         }
         return new FieldAlignEdge(baseEdge, fieldMapping);
     }
+
+    public static class FieldAlignEdgeSerializer extends Serializer<FieldAlignEdge> {
+
+        @Override
+        public void write(Kryo kryo, Output output, FieldAlignEdge object) {
+            kryo.writeClassAndObject(output, object.baseEdge);
+            if (object.fieldMapping != null) {
+                output.writeInt(object.fieldMapping.length, true);
+                for (int i : object.fieldMapping) {
+                    output.writeInt(i);
+                }
+            } else {
+                output.writeInt(0, true);
+            }
+        }
+
+        @Override
+        public FieldAlignEdge read(Kryo kryo, Input input, Class<FieldAlignEdge> type) {
+            RowEdge baseEdge = (RowEdge) kryo.readClassAndObject(input);
+            int[] fieldMapping = new int[input.readInt(true)];
+            for (int i = 0; i < fieldMapping.length; i++) {
+                fieldMapping[i] = input.readInt();
+            }
+            return new FieldAlignEdge(baseEdge, fieldMapping);
+        }
+
+        @Override
+        public FieldAlignEdge copy(Kryo kryo, FieldAlignEdge original) {
+            return new FieldAlignEdge(kryo.copy(original.baseEdge), Arrays.copyOf(original.fieldMapping, original.fieldMapping.length));
+        }
+
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignPath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignPath.java
@@ -19,6 +19,10 @@ import com.antgroup.geaflow.common.utils.ArrayUtil;
 import com.antgroup.geaflow.dsl.common.data.Path;
 import com.antgroup.geaflow.dsl.common.data.Row;
 import com.antgroup.geaflow.dsl.common.data.impl.DefaultPath;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -95,4 +99,36 @@ public class FieldAlignPath implements Path {
         }
         return pathNodes;
     }
+
+    public static class FieldAlignPathSerializer extends Serializer<FieldAlignPath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, FieldAlignPath object) {
+            kryo.writeClassAndObject(output, object.basePath);
+            if (object.fieldMapping != null) {
+                output.writeInt(object.fieldMapping.length, true);
+                for (int i : object.fieldMapping) {
+                    output.writeInt(i);
+                }
+            } else {
+                output.writeInt(0, true);
+            }
+        }
+
+        @Override
+        public FieldAlignPath read(Kryo kryo, Input input, Class<FieldAlignPath> type) {
+            Path basePath = (Path) kryo.readClassAndObject(input);
+            int[] fieldMapping = new int[input.readInt(true)];
+            for (int i = 0; i < fieldMapping.length; i++) {
+                fieldMapping[i] = input.readInt();
+            }
+            return new FieldAlignPath(basePath, fieldMapping);
+        }
+
+        @Override
+        public FieldAlignPath copy(Kryo kryo, FieldAlignPath original) {
+            return (FieldAlignPath) original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignVertex.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/FieldAlignVertex.java
@@ -22,6 +22,11 @@ import com.antgroup.geaflow.dsl.common.data.impl.types.DoubleVertex;
 import com.antgroup.geaflow.dsl.common.data.impl.types.IntVertex;
 import com.antgroup.geaflow.dsl.common.data.impl.types.LongVertex;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class FieldAlignVertex implements RowVertex {
@@ -136,4 +141,36 @@ public class FieldAlignVertex implements RowVertex {
         }
         return new FieldAlignVertex(baseVertex, fieldMapping);
     }
+
+    public static class FieldAlignVertexSerializer extends Serializer<FieldAlignVertex> {
+
+        @Override
+        public void write(Kryo kryo, Output output, FieldAlignVertex object) {
+            kryo.writeClassAndObject(output, object.baseVertex);
+            if (object.fieldMapping != null) {
+                output.writeInt(object.fieldMapping.length, true);
+                for (int i : object.fieldMapping) {
+                    output.writeInt(i);
+                }
+            } else {
+                output.writeInt(0, true);
+            }
+        }
+
+        @Override
+        public FieldAlignVertex read(Kryo kryo, Input input, Class<FieldAlignVertex> type) {
+            RowVertex baseVertex = (RowVertex) kryo.readClassAndObject(input);
+            int[] fieldMapping = new int[input.readInt(true)];
+            for (int i = 0; i < fieldMapping.length; i++) {
+                fieldMapping[i] = input.readInt();
+            }
+            return new FieldAlignVertex(baseVertex, fieldMapping);
+        }
+
+        @Override
+        public FieldAlignVertex copy(Kryo kryo, FieldAlignVertex original) {
+            return new FieldAlignVertex(kryo.copy(original.baseVertex), Arrays.copyOf(original.fieldMapping, original.fieldMapping.length));
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/IdOnlyVertex.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/data/IdOnlyVertex.java
@@ -20,10 +20,18 @@ import com.antgroup.geaflow.dsl.common.data.Row;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
 import com.antgroup.geaflow.dsl.common.types.VertexType;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
-public class IdOnlyVertex implements RowVertex {
+public class IdOnlyVertex implements RowVertex, KryoSerializable {
 
     private Object id;
+
+    private IdOnlyVertex() {
+
+    }
 
     private IdOnlyVertex(Object id) {
         this.id = id;
@@ -104,5 +112,15 @@ public class IdOnlyVertex implements RowVertex {
     @Override
     public void setBinaryLabel(BinaryString label) {
         throw new IllegalArgumentException("Illegal call on setBinaryLabel");
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        kryo.writeClassAndObject(output, this.id);
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        this.setId(kryo.readClassAndObject(input));
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/EODMessage.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/EODMessage.java
@@ -15,6 +15,10 @@
 package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
 import com.antgroup.geaflow.dsl.runtime.traversal.data.EndOfData;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,4 +61,26 @@ public class EODMessage implements IMessage {
     public List<EndOfData> getEodData() {
         return endOfDatas;
     }
+
+    public static class EODMessageSerializer extends Serializer<EODMessage> {
+
+        @Override
+        public void write(Kryo kryo, Output output, EODMessage object) {
+            // serialize endOfDatas using default CollectionSerializer
+            kryo.writeObject(output, object.getEodData());
+        }
+
+        @Override
+        public EODMessage read(Kryo kryo, Input input, Class<EODMessage> type) {
+            // deserialize endOfDatas using default CollectionSerializer
+            List<EndOfData> endOfDatas = kryo.readObject(input, ArrayList.class);
+            return new EODMessage(endOfDatas);
+        }
+
+        @Override
+        public EODMessage copy(Kryo kryo, EODMessage original) {
+            return new EODMessage(new ArrayList<>(original.getEodData()));
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/JoinPathMessage.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/JoinPathMessage.java
@@ -15,6 +15,10 @@
 package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
 import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -86,5 +90,24 @@ public class JoinPathMessage implements IPathMessage {
 
     public Set<Long> getSenders() {
         return senderId2Paths.keySet();
+    }
+
+    public static class JoinPathMessageSerializer extends Serializer<JoinPathMessage> {
+
+        @Override
+        public void write(Kryo kryo, Output output, JoinPathMessage object) {
+            kryo.writeClassAndObject(output, object.senderId2Paths);
+        }
+
+        @Override
+        public JoinPathMessage read(Kryo kryo, Input input, Class<JoinPathMessage> type) {
+            Map<Long, ITreePath> senderId2Paths = (Map<Long, ITreePath>)kryo.readClassAndObject(input);
+            return new JoinPathMessage(senderId2Paths);
+        }
+
+        @Override
+        public JoinPathMessage copy(Kryo kryo, JoinPathMessage original) {
+            return original.copy();
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/KeyGroupMessageImpl.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/KeyGroupMessageImpl.java
@@ -15,6 +15,10 @@
 package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -49,4 +53,24 @@ public class KeyGroupMessageImpl implements KeyGroupMessage {
     public List<Row> getGroupRows() {
         return groupRows;
     }
+
+    public static class KeyGroupMessageImplSerializer extends Serializer<KeyGroupMessageImpl> {
+
+        @Override
+        public void write(Kryo kryo, Output output, KeyGroupMessageImpl object) {
+            kryo.writeObject(output, object.groupRows);
+        }
+
+        @Override
+        public KeyGroupMessageImpl read(Kryo kryo, Input input, Class<KeyGroupMessageImpl> type) {
+            List<Row> groupRows = kryo.readObject(input, ArrayList.class);
+            return new KeyGroupMessageImpl(groupRows);
+        }
+
+        @Override
+        public KeyGroupMessageImpl copy(Kryo kryo, KeyGroupMessageImpl original) {
+            return new KeyGroupMessageImpl(new ArrayList<>(original.getGroupRows()));
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ParameterRequestMessage.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ParameterRequestMessage.java
@@ -15,6 +15,10 @@
 package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
 import com.antgroup.geaflow.dsl.runtime.traversal.data.ParameterRequest;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -66,4 +70,24 @@ public class ParameterRequestMessage implements IMessage {
     public boolean isEmpty() {
         return requests.isEmpty();
     }
+
+    public static class ParameterRequestMessageSerializer extends Serializer<ParameterRequestMessage> {
+
+        @Override
+        public void write(Kryo kryo, Output output, ParameterRequestMessage object) {
+            kryo.writeClassAndObject(output, object.requests);
+        }
+
+        @Override
+        public ParameterRequestMessage read(Kryo kryo, Input input, Class<ParameterRequestMessage> type) {
+            Set<ParameterRequest> requests = (Set<ParameterRequest>) kryo.readClassAndObject(input);
+            return new ParameterRequestMessage(requests);
+        }
+
+        @Override
+        public ParameterRequestMessage copy(Kryo kryo, ParameterRequestMessage original) {
+            return new ParameterRequestMessage(new HashSet<>(original.requests));
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ReturnMessageImpl.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ReturnMessageImpl.java
@@ -15,6 +15,10 @@
 package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
 import com.antgroup.geaflow.dsl.runtime.traversal.data.SingleValue;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,4 +116,25 @@ public class ReturnMessageImpl implements ReturnMessage {
                 + '}';
         }
     }
+
+    public static class ReturnMessageImplSerializer extends Serializer<ReturnMessageImpl> {
+
+        @Override
+        public void write(Kryo kryo, Output output, ReturnMessageImpl object) {
+            kryo.writeClassAndObject(output, object.returnKey2Value);
+        }
+
+        @Override
+        public ReturnMessageImpl read(Kryo kryo, Input input, Class<ReturnMessageImpl> type) {
+            Map<ReturnMessageImpl.ReturnKey, SingleValue> returnKey2Value =
+                (Map<ReturnMessageImpl.ReturnKey, SingleValue>) kryo.readClassAndObject(input);
+            return new ReturnMessageImpl(returnKey2Value);
+        }
+
+        @Override
+        public ReturnMessageImpl copy(Kryo kryo, ReturnMessageImpl original) {
+            return new ReturnMessageImpl(new HashMap<>(original.returnKey2Value));
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/EdgeTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/EdgeTreePath.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 import com.antgroup.geaflow.common.utils.ArrayUtil;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
@@ -157,4 +161,31 @@ public class EdgeTreePath extends AbstractSingleTreePath {
     public int hashCode() {
         return Objects.hash(parents, edges, requestIds);
     }
+
+
+    public static class EdgeTreePathSerializer extends Serializer<EdgeTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, EdgeTreePath object) {
+            kryo.writeClassAndObject(output, object.getRequestIds());
+            kryo.writeClassAndObject(output, object.getParents());
+            kryo.writeClassAndObject(output, object.getEdgeSet());
+        }
+
+        @Override
+        public EdgeTreePath read(Kryo kryo, Input input, Class<EdgeTreePath> type) {
+            Set<Object> requestIds = (Set<Object>) kryo.readClassAndObject(input);
+            List<ITreePath> parents = (List<ITreePath>) kryo.readClassAndObject(input);
+            EdgeSet edges = (EdgeSet) kryo.readClassAndObject(input);
+            EdgeTreePath treePath = EdgeTreePath.of(requestIds, edges);
+            treePath.parents.addAll(parents);
+            return treePath;
+        }
+
+        @Override
+        public EdgeTreePath copy(Kryo kryo, EdgeTreePath original) {
+            return (EdgeTreePath)original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/EmptyTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/EmptyTreePath.java
@@ -17,11 +17,15 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 import com.antgroup.geaflow.dsl.common.data.Path;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class EmptyTreePath extends AbstractSingleTreePath {
+public class EmptyTreePath extends AbstractSingleTreePath implements KryoSerializable {
 
     public static final ITreePath INSTANCE = new EmptyTreePath();
 
@@ -131,4 +135,15 @@ public class EmptyTreePath extends AbstractSingleTreePath {
     public boolean equalNode(ITreePath other) {
         return other.getNodeType() == NodeType.EMPTY_TREE;
     }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        // no fields to serialize
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        // no fields to deserialize
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/ParameterizedTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/ParameterizedTreePath.java
@@ -20,6 +20,10 @@ import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.IMessage;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageType;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -205,4 +209,28 @@ public class ParameterizedTreePath extends AbstractTreePath {
     public Row getParameter() {
         return parameter;
     }
+
+    public static class ParameterizedTreePathSerializer extends Serializer<ParameterizedTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, ParameterizedTreePath object) {
+            kryo.writeClassAndObject(output, object.baseTreePath);
+            kryo.writeClassAndObject(output, object.getRequestId());
+            kryo.writeClassAndObject(output, object.getParameter());
+        }
+
+        @Override
+        public ParameterizedTreePath read(Kryo kryo, Input input, Class<ParameterizedTreePath> type) {
+            ITreePath baseTreePath = (ITreePath) kryo.readClassAndObject(input);
+            Object requestId = kryo.readClassAndObject(input);
+            Row parameter = (Row) kryo.readClassAndObject(input);
+            return new ParameterizedTreePath(baseTreePath, requestId, parameter);
+        }
+
+        @Override
+        public ParameterizedTreePath copy(Kryo kryo, ParameterizedTreePath original) {
+            return (ParameterizedTreePath) original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/SourceEdgeTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/SourceEdgeTreePath.java
@@ -16,6 +16,10 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 
 import com.antgroup.geaflow.common.utils.ArrayUtil;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,4 +127,26 @@ public class SourceEdgeTreePath extends AbstractSingleTreePath {
     public int hashCode() {
         return Objects.hash(edges, requestIds);
     }
+
+    public static class SourceEdgeTreePathSerializer extends Serializer<SourceEdgeTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, SourceEdgeTreePath object) {
+            kryo.writeClassAndObject(output, object.getRequestIds());
+            kryo.writeClassAndObject(output, object.getEdgeSet());
+        }
+
+        @Override
+        public SourceEdgeTreePath read(Kryo kryo, Input input, Class<SourceEdgeTreePath> type) {
+            Set<Object> requestIds = (Set<Object>) kryo.readClassAndObject(input);
+            EdgeSet edges = (EdgeSet) kryo.readClassAndObject(input);
+            return SourceEdgeTreePath.of(requestIds, edges);
+        }
+
+        @Override
+        public SourceEdgeTreePath copy(Kryo kryo, SourceEdgeTreePath original) {
+            return (SourceEdgeTreePath) original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/SourceVertexTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/SourceVertexTreePath.java
@@ -16,6 +16,10 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 
 import com.antgroup.geaflow.common.utils.ArrayUtil;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.List;
@@ -131,4 +135,26 @@ public class SourceVertexTreePath extends AbstractSingleTreePath {
     public int hashCode() {
         return Objects.hash(vertex, requestIds);
     }
+
+    public static class SourceVertexTreePathSerializer extends Serializer<SourceVertexTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, SourceVertexTreePath object) {
+            kryo.writeClassAndObject(output, object.getRequestIds());
+            kryo.writeClassAndObject(output, object.getVertex());
+        }
+
+        @Override
+        public SourceVertexTreePath read(Kryo kryo, Input input, Class<SourceVertexTreePath> type) {
+            Set<Object> requestIds = (Set<Object>) kryo.readClassAndObject(input);
+            RowVertex vertex = (RowVertex) kryo.readClassAndObject(input);
+            return SourceVertexTreePath.of(requestIds, vertex);
+        }
+
+        @Override
+        public SourceVertexTreePath copy(Kryo kryo, SourceVertexTreePath original) {
+            return (SourceVertexTreePath) original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/UnionTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/UnionTreePath.java
@@ -17,6 +17,10 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 import com.antgroup.geaflow.dsl.common.data.Path;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -314,4 +318,24 @@ public class UnionTreePath extends AbstractTreePath {
         }
         return paths;
     }
+
+    public static class UnionTreePathSerializer extends Serializer<UnionTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, UnionTreePath object) {
+            kryo.writeClassAndObject(output, object.getNodes());
+        }
+
+        @Override
+        public UnionTreePath read(Kryo kryo, Input input, Class<UnionTreePath> type) {
+            List<ITreePath> nodes = (List<ITreePath>) kryo.readClassAndObject(input);
+            return new UnionTreePath(nodes);
+        }
+
+        @Override
+        public UnionTreePath copy(Kryo kryo, UnionTreePath original) {
+            return (UnionTreePath) original.copy();
+        }
+    }
+
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/VertexTreePath.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/path/VertexTreePath.java
@@ -16,6 +16,10 @@ package com.antgroup.geaflow.dsl.runtime.traversal.path;
 
 import com.antgroup.geaflow.common.utils.ArrayUtil;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
@@ -150,4 +154,30 @@ public class VertexTreePath extends AbstractSingleTreePath {
     public int hashCode() {
         return Objects.hash(parents, vertex, requestIds);
     }
+
+    public static class VertexTreePathSerializer extends Serializer<VertexTreePath> {
+
+        @Override
+        public void write(Kryo kryo, Output output, VertexTreePath object) {
+            kryo.writeClassAndObject(output, object.getRequestIds());
+            kryo.writeClassAndObject(output, object.getParents());
+            kryo.writeClassAndObject(output, object.getVertex());
+        }
+
+        @Override
+        public VertexTreePath read(Kryo kryo, Input input, Class<VertexTreePath> type) {
+            Set<Object> requestIds = (Set<Object>) kryo.readClassAndObject(input);
+            List<ITreePath> parents = (List<ITreePath>) kryo.readClassAndObject(input);
+            RowVertex vertex = (RowVertex) kryo.readClassAndObject(input);
+            VertexTreePath vertexTreePath = VertexTreePath.of(requestIds, vertex);
+            vertexTreePath.parents.addAll(parents);
+            return vertexTreePath;
+        }
+
+        @Override
+        public VertexTreePath copy(Kryo kryo, VertexTreePath original) {
+            return original.copy();
+        }
+    }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
GeaFlow uses Kryo as the default serializer, but some data types in the current DSL module, such as Path, Message, and Row, have not been registered in Kryo, which may lead to a decrease in the performance of the serializer. This pr supports registration optimization for these types.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
