### PR TITLE
[ISSUE-96] Support aggregate operator rollback in the dynamic graph

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/utils/ReflectionUtil.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/utils/ReflectionUtil.java
@@ -83,4 +83,9 @@ public final class ReflectionUtil {
         throw new NoSuchFieldException(fieldName);
     }
 
+    public static void setField(Object instance, String fieldName, Object value) throws Exception {
+        Field field = getField(instance.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
 }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/AbstractCycleSchedulerContext.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/AbstractCycleSchedulerContext.java
@@ -57,14 +57,20 @@ public abstract class AbstractCycleSchedulerContext implements ICycleSchedulerCo
         this.cycle = cycle;
         this.parentContext = parentContext;
 
-        long startIterationId;
         if (parentContext != null) {
             // Get worker manager from parent context, no need to init.
             this.workerManager = parentContext.getSchedulerWorkerManager();
-            startIterationId = parentContext.getCurrentIterationId();
         } else {
             this.workerManager = ScheduledWorkerManagerFactory.createScheduledWorkerManager(cycle.getConfig(),
                 getHaLevel());
+        }
+    }
+
+    public void init() {
+        long startIterationId;
+        if (parentContext != null) {
+            startIterationId = parentContext.getCurrentIterationId();
+        } else {
             startIterationId = DEFAULT_INITIAL_ITERATION_ID;
         }
         this.finishIterationId = cycle.getIterationCount() == Long.MAX_VALUE

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/CheckpointSchedulerContext.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/CheckpointSchedulerContext.java
@@ -43,6 +43,11 @@ public class CheckpointSchedulerContext extends AbstractCycleSchedulerContext im
             throw new GeaflowRuntimeException("not support nested scheduler context fo checkpoint");
         }
         this.checkpointDuration = getConfig().getLong(BATCH_NUMBER_PER_CHECKPOINT);
+    }
+
+    @Override
+    public void init() {
+        super.init();
         this.schedulerStateMap.put(getCurrentIterationId(),
             Arrays.asList(SchedulerState.INIT, SchedulerState.EXECUTE));
         checkpoint(new CycleCheckpointFunction());

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/CycleSchedulerContextFactory.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/CycleSchedulerContextFactory.java
@@ -30,21 +30,26 @@ public class CycleSchedulerContextFactory {
     }
 
     public static ICycleSchedulerContext create(IExecutionCycle cycle, ICycleSchedulerContext parent) {
+        AbstractCycleSchedulerContext context;
         switch (cycle.getHighAvailableLevel()) {
             case CHECKPOINT:
                 LOGGER.info("create checkpoint scheduler context");
-                return new CheckpointSchedulerContext(cycle, parent);
+                context = new CheckpointSchedulerContext(cycle, parent);
+                break;
             case REDO:
                 if (cycle.getType() == ExecutionCycleType.ITERATION) {
                     LOGGER.info("create iteration redo scheduler context");
-                    return new IterationRedoSchedulerContext(cycle, parent);
+                    context = new IterationRedoSchedulerContext(cycle, parent);
                 } else {
                     LOGGER.info("create redo scheduler context");
-                    return new RedoSchedulerContext(cycle, parent);
+                    context = new RedoSchedulerContext(cycle, parent);
                 }
+                break;
             default:
                 throw new GeaflowRuntimeException(String.format("not support ha level %s for cycle %s",
                     cycle.getHighAvailableLevel(), cycle.getCycleId()));
         }
+        context.init();
+        return context;
     }
 }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/RedoSchedulerContext.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/context/RedoSchedulerContext.java
@@ -16,14 +16,38 @@ package com.antgroup.geaflow.runtime.core.scheduler.context;
 
 import com.antgroup.geaflow.ha.runtime.HighAvailableLevel;
 import com.antgroup.geaflow.runtime.core.scheduler.cycle.IExecutionCycle;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RedoSchedulerContext extends AbstractCycleSchedulerContext {
 
     public RedoSchedulerContext(IExecutionCycle cycle, ICycleSchedulerContext parentContext) {
         super(cycle, parentContext);
-        this.schedulerStateMap.put(getCurrentIterationId(),
-            Arrays.asList(SchedulerState.INIT, SchedulerState.EXECUTE));
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        List<SchedulerState> states = new ArrayList<>();
+        states.add(SchedulerState.INIT);
+        if (parentContext != null) {
+            // Add states of parent if not exists.
+            List<SchedulerState> parentStates = parentContext.getSchedulerState(parentContext.getCurrentIterationId());
+            if (parentStates != null) {
+                for (SchedulerState state : parentStates) {
+                    addSchedulerState(states, state);
+                }
+            }
+        }
+        // Add execute state.
+        addSchedulerState(states, SchedulerState.EXECUTE);
+        this.schedulerStateMap.put(getCurrentIterationId(), states);
+    }
+
+    private void addSchedulerState(List<SchedulerState> states, SchedulerState state) {
+        if (!states.contains(state)) {
+            states.add(state);
+        }
     }
 
     @Override

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleSchedulerTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleSchedulerTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+package com.antgroup.geaflow.runtime.core.scheduler;
+
+import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.CLUSTER_ID;
+import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.CONTAINER_HEAP_SIZE_MB;
+import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.JOB_UNIQUE_ID;
+import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.RUN_LOCAL_MODE;
+import static com.antgroup.geaflow.common.config.keys.FrameworkConfigKeys.SYSTEM_STATE_BACKEND_TYPE;
+import static com.antgroup.geaflow.ha.runtime.HighAvailableLevel.CHECKPOINT;
+
+import com.antgroup.geaflow.cluster.common.ExecutionIdGenerator;
+import com.antgroup.geaflow.cluster.protocol.EventType;
+import com.antgroup.geaflow.cluster.protocol.IEvent;
+import com.antgroup.geaflow.cluster.system.ClusterMetaStore;
+import com.antgroup.geaflow.common.config.Configuration;
+import com.antgroup.geaflow.common.exception.GeaflowRuntimeException;
+import com.antgroup.geaflow.common.utils.ReflectionUtil;
+import com.antgroup.geaflow.core.graph.ExecutionTask;
+import com.antgroup.geaflow.core.graph.ExecutionTaskType;
+import com.antgroup.geaflow.core.graph.ExecutionVertex;
+import com.antgroup.geaflow.core.graph.ExecutionVertexGroup;
+import com.antgroup.geaflow.runtime.core.protocol.ComposeEvent;
+import com.antgroup.geaflow.runtime.core.protocol.LaunchSourceEvent;
+import com.antgroup.geaflow.runtime.core.scheduler.context.CheckpointSchedulerContext;
+import com.antgroup.geaflow.runtime.core.scheduler.context.CycleSchedulerContextFactory;
+import com.antgroup.geaflow.runtime.core.scheduler.context.ICycleSchedulerContext;
+import com.antgroup.geaflow.runtime.core.scheduler.cycle.ExecutionGraphCycle;
+import com.antgroup.geaflow.runtime.core.scheduler.cycle.ExecutionNodeCycle;
+import com.antgroup.geaflow.shuffle.service.ShuffleManager;
+import com.antgroup.geaflow.state.StoreType;
+import com.antgroup.geaflow.stats.collector.StatsCollectorFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ExecutionGraphCycleSchedulerTest extends BaseCycleSchedulerTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionGraphCycleSchedulerTest.class);
+
+    private static CheckpointSchedulerContext mockPersistContext;
+    private Configuration configuration;
+
+    @BeforeMethod
+    public void setUp() {
+        Map<String, String> config = new HashMap<>();
+        config.put(JOB_UNIQUE_ID.getKey(), "scheduler-fo-test" + System.currentTimeMillis());
+        config.put(RUN_LOCAL_MODE.getKey(), "true");
+        config.put(SYSTEM_STATE_BACKEND_TYPE.getKey(), StoreType.MEMORY.name());
+        config.put(CONTAINER_HEAP_SIZE_MB.getKey(), String.valueOf(1024));
+        configuration = new Configuration(config);
+        ExecutionIdGenerator.init(0);
+        ShuffleManager.init(configuration);
+        ShuffleManager.getInstance().initShuffleMaster();
+        StatsCollectorFactory.init(configuration);
+    }
+
+    @AfterMethod
+    public void cleanUp() {
+        ClusterMetaStore.close();
+    }
+
+    @Test
+    public void testSimplePipeline() {
+        ClusterMetaStore.init(0, configuration);
+        ExecutionGraphCycleScheduler scheduler = new ExecutionGraphCycleScheduler();
+        processor.register(scheduler);
+
+        CheckpointSchedulerContext context = (CheckpointSchedulerContext) CycleSchedulerContextFactory.create(buildMockGraphCycle(), null);
+        mockPersistContext = context;
+        scheduler.init(context);
+        scheduler.execute();
+        scheduler.close();
+
+
+        List<IEvent> events = processor.getProcessed();
+        LOGGER.info("processed events {}", events.size());
+        for (IEvent event : events) {
+            LOGGER.info("{}", event);
+        }
+
+        int eventWindowId = 1;
+        int eventIndex = 0;
+        int eventSize = 32;
+        Assert.assertEquals(eventSize, events.size());
+        Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+        Assert.assertEquals(EventType.CREATE_TASK, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+        Assert.assertEquals(EventType.CREATE_WORKER, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+        eventIndex++;
+
+        Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+        Assert.assertEquals(EventType.INIT_CYCLE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+        Assert.assertEquals(EventType.LAUNCH_SOURCE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+        Assert.assertEquals(eventWindowId++, ((LaunchSourceEvent) ((ComposeEvent) events.get(eventIndex)).getEventList().get(1)).getIterationWindowId());
+        eventIndex++;
+
+        Assert.assertEquals(EventType.STASH_WORKER, events.get(eventIndex++).getEventType());
+
+        Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex++).getEventType());
+
+        while (eventIndex < eventSize - 1) {
+            Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+            Assert.assertEquals(EventType.POP_WORKER, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+            Assert.assertEquals(EventType.LAUNCH_SOURCE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+            Assert.assertEquals(eventWindowId++, ((LaunchSourceEvent) ((ComposeEvent) events.get(eventIndex)).getEventList().get(1)).getIterationWindowId());
+            eventIndex++;
+
+            Assert.assertEquals(EventType.STASH_WORKER, events.get(eventIndex++).getEventType());
+
+            Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex++).getEventType());
+        }
+
+        Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex).getEventType());
+    }
+
+    @Test
+    private void testPipelineAfterRecover() {
+
+        configuration.put(CLUSTER_ID, "restart");
+        ClusterMetaStore.init(0, configuration);
+        ClusterMetaStore.getInstance().saveWindowId(5L);
+
+        ExecutionGraphCycleScheduler scheduler = new ExecutionGraphCycleScheduler();
+        processor.register(scheduler);
+
+        // mock recover context from previous case.
+        CheckpointSchedulerContext newContext = (CheckpointSchedulerContext) CycleSchedulerContextFactory.create(buildMockGraphCycle(), null);
+        CheckpointSchedulerContext context = (CheckpointSchedulerContext) CheckpointSchedulerContext.build(() -> newContext);
+        context.init(6);
+        context.getSchedulerStateMap().put(context.getCurrentIterationId(),
+            Arrays.asList(ICycleSchedulerContext.SchedulerState.ROLLBACK,
+                ICycleSchedulerContext.SchedulerState.EXECUTE));
+
+        scheduler.init(context);
+        scheduler.execute();
+        scheduler.close();
+
+        List<IEvent> events = processor.getProcessed();
+        LOGGER.info("processed events {}", events.size());
+        for (IEvent event : events) {
+            LOGGER.info("{}", event);
+        }
+
+        int eventWindowId = 6;
+        int eventIndex = 0;
+        int eventSize = 17;
+        Assert.assertEquals(eventSize, events.size());
+        Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+        Assert.assertEquals(EventType.CREATE_TASK, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+        Assert.assertEquals(EventType.CREATE_WORKER, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+        eventIndex++;
+
+        Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+        Assert.assertEquals(EventType.INIT_CYCLE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+        Assert.assertEquals(EventType.ROLLBACK, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+        Assert.assertEquals(EventType.LAUNCH_SOURCE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(2).getEventType());
+        Assert.assertEquals(eventWindowId++, ((LaunchSourceEvent) ((ComposeEvent) events.get(eventIndex)).getEventList().get(2)).getIterationWindowId());
+        eventIndex++;
+
+        Assert.assertEquals(EventType.STASH_WORKER, events.get(eventIndex++).getEventType());
+
+        Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex++).getEventType());
+
+        while (eventIndex < eventSize - 1) {
+            Assert.assertEquals(EventType.COMPOSE, events.get(eventIndex).getEventType());
+            Assert.assertEquals(EventType.POP_WORKER, ((ComposeEvent) events.get(eventIndex)).getEventList().get(0).getEventType());
+            Assert.assertEquals(EventType.LAUNCH_SOURCE, ((ComposeEvent) events.get(eventIndex)).getEventList().get(1).getEventType());
+            Assert.assertEquals(eventWindowId++, ((LaunchSourceEvent) ((ComposeEvent) events.get(eventIndex)).getEventList().get(1)).getIterationWindowId());
+            eventIndex++;
+
+            Assert.assertEquals(EventType.STASH_WORKER, events.get(eventIndex++).getEventType());
+
+            Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex++).getEventType());
+        }
+
+        Assert.assertEquals(EventType.CLEAN_ENV, events.get(eventIndex).getEventType());
+    }
+
+
+    private ExecutionGraphCycle buildMockGraphCycle() {
+
+        ExecutionGraphCycle graphCycle = new ExecutionGraphCycle(0, "graph_cycle", 0,
+            1, 10, configuration, "driver_id");
+        ExecutionNodeCycle nodeCycle = buildMockIterationNodeCycle(configuration);
+
+        graphCycle.addCycle(nodeCycle);
+        try {
+            ReflectionUtil.setField(graphCycle, "haLevel", CHECKPOINT);
+        } catch (Exception e) {
+            throw new GeaflowRuntimeException(e);
+        }
+
+        return graphCycle;
+    }
+
+    protected ExecutionNodeCycle buildMockIterationNodeCycle(Configuration configuration) {
+
+        long finishIterationId = 1;
+        ExecutionVertexGroup vertexGroup = new ExecutionVertexGroup(1);
+        vertexGroup.getCycleGroupMeta().setFlyingCount(1);
+        vertexGroup.getCycleGroupMeta().setIterationCount(finishIterationId);
+        vertexGroup.getCycleGroupMeta().setIterative(false);
+        ExecutionVertex vertex = new ExecutionVertex(0, "test");
+        vertex.setParallelism(1);
+        vertexGroup.getVertexMap().put(0, vertex);
+        vertexGroup.putVertexId2InEdgeIds(0, new ArrayList<>());
+        vertexGroup.putVertexId2OutEdgeIds(0, new ArrayList<>());
+
+        List<ExecutionTask> headTasks = new ArrayList<>();
+        List<ExecutionTask> tailTasks = new ArrayList<>();
+        for (int i = 0; i < vertex.getParallelism(); i++) {
+            ExecutionTask task = new ExecutionTask(i, i, vertex.getParallelism(), vertex.getParallelism(), vertex.getParallelism(), vertex.getVertexId());
+            task.setExecutionTaskType(ExecutionTaskType.head);
+            tailTasks.add(task);
+            headTasks.add(task);
+        }
+
+        ExecutionNodeCycle cycle = new ExecutionNodeCycle(0, "test", vertexGroup, configuration, "driver_id");
+        cycle.setCycleHeads(headTasks);
+        cycle.setCycleTails(tailTasks);
+        cycle.setTasks(headTasks);
+        return cycle;
+    }
+
+}

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/PipelineCycleSchedulerTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/PipelineCycleSchedulerTest.java
@@ -30,6 +30,7 @@ import com.antgroup.geaflow.runtime.core.protocol.ComposeEvent;
 import com.antgroup.geaflow.runtime.core.protocol.LaunchSourceEvent;
 import com.antgroup.geaflow.runtime.core.protocol.RollbackCycleEvent;
 import com.antgroup.geaflow.runtime.core.scheduler.context.CheckpointSchedulerContext;
+import com.antgroup.geaflow.runtime.core.scheduler.context.CycleSchedulerContextFactory;
 import com.antgroup.geaflow.runtime.core.scheduler.context.ICycleSchedulerContext;
 import com.antgroup.geaflow.runtime.core.scheduler.cycle.ExecutionNodeCycle;
 import com.antgroup.geaflow.shuffle.service.ShuffleManager;
@@ -77,7 +78,7 @@ public class PipelineCycleSchedulerTest extends BaseCycleSchedulerTest {
         ShuffleManager.getInstance().initShuffleMaster();
         StatsCollectorFactory.init(configuration);
 
-        CheckpointSchedulerContext context = new CheckpointSchedulerContext(buildMockCycle(configuration), null);
+        CheckpointSchedulerContext context = (CheckpointSchedulerContext) CycleSchedulerContextFactory.create(buildMockCycle(configuration), null);
         mockPersistContext = context;
         scheduler.init(context);
         scheduler.execute();

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/context/AbstractCycleSchedulerContextTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/context/AbstractCycleSchedulerContextTest.java
@@ -34,6 +34,7 @@ public class AbstractCycleSchedulerContextTest extends BaseCycleSchedulerContext
         ExecutionNodeCycle cycle = buildMockCycle(false);
         cycle.getVertexGroup().getCycleGroupMeta().setIterationCount(finishIterationId);
         CheckpointSchedulerContext context = new CheckpointSchedulerContext(cycle, null);
+        context.init();
 
         long checkpointId = 20L;
         context.checkpoint(checkpointId);
@@ -49,6 +50,7 @@ public class AbstractCycleSchedulerContextTest extends BaseCycleSchedulerContext
         ExecutionNodeCycle cycle = buildMockCycle(false);
         cycle.getVertexGroup().getCycleGroupMeta().setIterationCount(finishIterationId);
         CheckpointSchedulerContext context = new CheckpointSchedulerContext(cycle, null);
+        context.init();
 
         long checkpointId = 20L;
         context.checkpoint(checkpointId);
@@ -73,6 +75,7 @@ public class AbstractCycleSchedulerContextTest extends BaseCycleSchedulerContext
         ExecutionNodeCycle cycle = buildMockCycle(false);
         cycle.getVertexGroup().getCycleGroupMeta().setIterationCount(finishIterationId);
         CheckpointSchedulerContext context = new CheckpointSchedulerContext(cycle, null);
+        context.init();
 
         // do checkpoint
         long checkpointId = 20L;
@@ -81,7 +84,7 @@ public class AbstractCycleSchedulerContextTest extends BaseCycleSchedulerContext
         // clean checkpoint cycle.
         ClusterMetaStore.getInstance(0, new Configuration()).clean();
         CheckpointSchedulerContext newContext =
-            (CheckpointSchedulerContext) CheckpointSchedulerContext.build(() -> new CheckpointSchedulerContext(cycle, null));
+            (CheckpointSchedulerContext) CheckpointSchedulerContext.build(() -> CycleSchedulerContextFactory.create(cycle, null));
 
         long currentIterationId = checkpointId + 1;
         context.init(currentIterationId);
@@ -100,6 +103,7 @@ public class AbstractCycleSchedulerContextTest extends BaseCycleSchedulerContext
 
         ExecutionNodeCycle cycle = buildMockCycle(false);
         CheckpointSchedulerContext context = new CheckpointSchedulerContext(cycle, null);
+        context.init();
 
         // not do checkpoint at 17
         long checkpointId = 17L;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Aggregation statements in dynamic graphs save their state in DFS. An error occurs when restarting the graph after it has stopped. The issue has been identified as the lack of rollback support for the Agg operator. The Agg operator needs to support rollback. This pr is to support aggregate operator rollback in the dynamic graph.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
