### PR TITLE
[ISSUE-98] fix async state writer bug

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/config/keys/ExecutionConfigKeys.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/config/keys/ExecutionConfigKeys.java
@@ -491,7 +491,7 @@ public class ExecutionConfigKeys implements Serializable {
 
     public static final ConfigKey STATS_METRIC_FLUSH_THREADS = ConfigKeys
         .key("geaflow.metric.flush.threads")
-        .defaultValue(2)
+        .defaultValue(1)
         .description("stats metrics flush thread number");
 
     public static final ConfigKey STATS_METRIC_FLUSH_BATCH_SIZE = ConfigKeys
@@ -501,7 +501,7 @@ public class ExecutionConfigKeys implements Serializable {
 
     public static final ConfigKey STATS_METRIC_FLUSH_INTERVAL_MS = ConfigKeys
         .key("geaflow.metric.flush.interval.ms")
-        .defaultValue(100)
+        .defaultValue(1000)
         .description("stats flush interval in ms");
 
     public static final ConfigKey ENABLE_DETAIL_METRIC = ConfigKeys


### PR DESCRIPTION
## Description
当前 AsyncKvStoreWriter 默认启动 2 个异步线程 flush metric，但是由于在计算 sleep gap 时有 bug，会导致计算出负值，形成 while true 循环，导致 2 个线程占用过多的 CPU。

The current AsyncKvStoreWriter starts two asynchronous threads by default to flush metric. However, due to a bug in calculating the sleep gap, negative values may be computed, which leads to an infinite while-true loop and causes the two threads to consume too much CPU.

## Solution
‒ flush 之后强制 sleep，不再占用 CPU 资源
‒ 将 flush 线程数改为 1 个
‒ 将 flush interval 改为 1s

- Force sleep after flush to release CPU resources.
- Change the number of flush threads to 1.
- Change the flush interval to 1 second.