### PR TITLE
[ISSUE-100] fix shuffle memory tracker log

### DIFF
--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/AbstractBuffer.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/AbstractBuffer.java
@@ -44,10 +44,15 @@ public abstract class AbstractBuffer implements OutBuffer {
         return memoryTrack;
     }
 
+    protected void requireMemory(long dataSize) {
+        if (memoryTrack) {
+            ShuffleMemoryTracker.getInstance().requireMemory(dataSize);
+        }
+    }
+
     protected void releaseMemory(long dataSize) {
         if (memoryTrack) {
-            ShuffleMemoryTracker tracker = ShuffleMemoryTracker.getInstance();
-            tracker.releaseMemory(dataSize);
+            ShuffleMemoryTracker.getInstance().releaseMemory(dataSize);
         }
     }
 

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/HeapBuffer.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/HeapBuffer.java
@@ -29,12 +29,13 @@ public class HeapBuffer extends AbstractBuffer {
     private byte[] bytes;
 
     public HeapBuffer(byte[] bytes) {
-        this.bytes = bytes;
+        this(bytes, false);
     }
 
     public HeapBuffer(byte[] bytes, boolean memoryTrack) {
         super(memoryTrack);
         this.bytes = bytes;
+        this.requireMemory(bytes.length);
     }
 
     @Override

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/PipeBuffer.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/pipeline/buffer/PipeBuffer.java
@@ -25,7 +25,7 @@ public class PipeBuffer implements Serializable {
     private final boolean isFinish;
 
     public PipeBuffer(byte[] buffer, long batchId, boolean isData) {
-        this.buffer = new HeapBuffer(buffer);
+        this.buffer = new HeapBuffer(buffer, true);
         this.batchId = batchId;
         this.isData = isData;
         this.count = 0;

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/writer/ShardBuffer.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/api/writer/ShardBuffer.java
@@ -54,7 +54,7 @@ public abstract class ShardBuffer<T, R> {
 
     public void init(IWriterContext writerContext) {
         this.config = writerContext.getConfig();
-        this.memoryTracker = ShuffleMemoryTracker.getInstance(config);
+        this.memoryTracker = ShuffleMemoryTracker.getInstance();
 
         this.targetChannels = writerContext.getTargetChannelNum();
         this.pipelineId = writerContext.getPipelineInfo().getPipelineId();
@@ -94,9 +94,6 @@ public abstract class ShardBuffer<T, R> {
     protected void send(int selectChannel, OutBuffer outBuffer, long batchId) {
         sendBuffer(selectChannel, outBuffer, batchId);
         this.bytesCounter[selectChannel] += outBuffer.getBufferSize();
-        if (outBuffer.isMemoryTracking()) {
-            memoryTracker.requireMemory(outBuffer.getBufferSize());
-        }
     }
 
     protected void sendBuffer(int sliceIndex, OutBuffer buffer, long batchId) {

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/memory/ShuffleMemoryTracker.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/memory/ShuffleMemoryTracker.java
@@ -33,7 +33,7 @@ public class ShuffleMemoryTracker {
     private final long maxShuffleSize;
     private final AtomicLong usedMemory;
 
-    private static ShuffleMemoryTracker INSTANCE;
+    private static volatile ShuffleMemoryTracker INSTANCE;
 
     private ShuffleMemoryTracker(Configuration config) {
         boolean memoryPool = config.getBoolean(SHUFFLE_MEMORY_POOL_ENABLE);
@@ -57,7 +57,7 @@ public class ShuffleMemoryTracker {
         return INSTANCE;
     }
 
-    public static synchronized ShuffleMemoryTracker getInstance() {
+    public static ShuffleMemoryTracker getInstance() {
         return INSTANCE;
     }
 

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/service/ShuffleManager.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/service/ShuffleManager.java
@@ -19,6 +19,7 @@ import com.antgroup.geaflow.shuffle.api.reader.IShuffleReader;
 import com.antgroup.geaflow.shuffle.api.reader.ReaderContext;
 import com.antgroup.geaflow.shuffle.api.writer.IShuffleWriter;
 import com.antgroup.geaflow.shuffle.config.ShuffleConfig;
+import com.antgroup.geaflow.shuffle.memory.ShuffleMemoryTracker;
 import com.antgroup.geaflow.shuffle.network.netty.ConnectionManager;
 import com.antgroup.geaflow.shuffle.service.impl.AutoShuffleService;
 import java.io.IOException;
@@ -45,6 +46,7 @@ public class ShuffleManager {
     public static synchronized ShuffleManager init(Configuration config) {
         if (INSTANCE == null) {
             INSTANCE = new ShuffleManager(config);
+            ShuffleMemoryTracker.getInstance(config);
         }
         return INSTANCE;
     }

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/api/pipeline/fetcher/OneShardFetcherTest.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/api/pipeline/fetcher/OneShardFetcherTest.java
@@ -26,6 +26,7 @@ import com.antgroup.geaflow.shuffle.api.pipeline.channel.LocalInputChannel;
 import com.antgroup.geaflow.shuffle.api.pipeline.channel.RemoteInputChannel;
 import com.antgroup.geaflow.shuffle.config.ShuffleConfig;
 import com.antgroup.geaflow.shuffle.memory.ShuffleDataManager;
+import com.antgroup.geaflow.shuffle.memory.ShuffleMemoryTracker;
 import com.antgroup.geaflow.shuffle.message.PipelineSliceMeta;
 import com.antgroup.geaflow.shuffle.message.SliceId;
 import com.antgroup.geaflow.shuffle.network.IConnectionManager;
@@ -51,6 +52,7 @@ public class OneShardFetcherTest {
     public void setup() {
         Configuration configuration = new Configuration();
         configuration.put(ExecutionConfigKeys.JOB_APP_NAME, "default");
+        configuration.put(ExecutionConfigKeys.CONTAINER_HEAP_SIZE_MB, String.valueOf(1024));
         ShuffleConfig config = ShuffleConfig.getInstance(configuration);
         connectionManager = new ConnectionManager(config);
     }
@@ -62,6 +64,7 @@ public class OneShardFetcherTest {
 
     @Test
     public void testCreate() {
+        ShuffleMemoryTracker.getInstance(ShuffleConfig.getInstance().getConfig());
         List<PipelineSliceMeta> inputSlices = new ArrayList<>();
         ShuffleAddress address = connectionManager.getShuffleAddress();
         PipelineSliceMeta slice1 = new PipelineSliceMeta(0, 0, -1, 0, address);
@@ -94,6 +97,7 @@ public class OneShardFetcherTest {
 
     @Test
     public void testRemoteFetch() throws IOException, InterruptedException {
+        ShuffleMemoryTracker.getInstance(ShuffleConfig.getInstance().getConfig());
         List<PipelineSliceMeta> inputSlices = new ArrayList<>();
         ShuffleAddress address = connectionManager.getShuffleAddress();
         SliceId sliceId = new SliceId(-1, 0, 0, 0);

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/api/writer/SpillableShardBufferTest.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/api/writer/SpillableShardBufferTest.java
@@ -47,6 +47,7 @@ public class SpillableShardBufferTest {
         writerContext.setChannelNum(1);
         writerContext.setShuffleDescriptor(new ShuffleDescriptor());
         shardBuffer.init(writerContext);
+        ShuffleMemoryTracker.getInstance(config);
         int[] channels = new int[]{0};
 
         for (int i = 0; i < 10000; i++) {

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/memory/ShuffleMemoryTrackerTest.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/test/java/com/antgroup/geaflow/shuffle/memory/ShuffleMemoryTrackerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.shuffle.memory;
+
+import com.antgroup.geaflow.common.config.Configuration;
+import com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys;
+import com.antgroup.geaflow.shuffle.api.pipeline.buffer.HeapBuffer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ShuffleMemoryTrackerTest {
+
+    @Test
+    public void testRequireAndRelease() {
+        Configuration configuration = new Configuration();
+        configuration.put(ExecutionConfigKeys.CONTAINER_HEAP_SIZE_MB, String.valueOf(1024));
+        ShuffleMemoryTracker.getInstance(configuration).dispose();
+        ShuffleMemoryTracker tracker = ShuffleMemoryTracker.getInstance(configuration);
+
+        byte[] bytes1 = new byte[100];
+        HeapBuffer buffer1 = new HeapBuffer(bytes1);
+        Assert.assertEquals(tracker.getUsedMemory(), 0);
+
+        byte[] bytes2 = new byte[200];
+        HeapBuffer buffer2 = new HeapBuffer(bytes2, true);
+        Assert.assertEquals(tracker.getUsedMemory(), 200);
+
+        buffer1.release();
+        Assert.assertEquals(tracker.getUsedMemory(), 200);
+        buffer2.release();
+        Assert.assertEquals(tracker.getUsedMemory(), 0);
+        tracker.dispose();
+    }
+
+}

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/PipelineCycleSchedulerTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/PipelineCycleSchedulerTest.java
@@ -14,6 +14,7 @@
 
 package com.antgroup.geaflow.runtime.core.scheduler;
 
+import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.CONTAINER_HEAP_SIZE_MB;
 import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.JOB_UNIQUE_ID;
 import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.RUN_LOCAL_MODE;
 import static com.antgroup.geaflow.common.config.keys.FrameworkConfigKeys.SYSTEM_STATE_BACKEND_TYPE;
@@ -61,6 +62,7 @@ public class PipelineCycleSchedulerTest extends BaseCycleSchedulerTest {
         config.put(JOB_UNIQUE_ID.getKey(), "scheduler-fo-test" + System.currentTimeMillis());
         config.put(RUN_LOCAL_MODE.getKey(), "true");
         config.put(SYSTEM_STATE_BACKEND_TYPE.getKey(), StoreType.MEMORY.name());
+        config.put(CONTAINER_HEAP_SIZE_MB.getKey(), String.valueOf(1024));
         configuration = new Configuration(config);
         ClusterMetaStore.init(0, configuration);
     }


### PR DESCRIPTION
## Description
‒ 在 Shuffle 组件中，ShuffleMemoryTracker 用来追踪 Shuffle 模块使用的内存量，通过 require 申请内存用量，通过 release 释放内存用量。
‒ 目前，在 Shuffle write 端有 require，使用完有 release，但是在 shuffle read 端没有 require，release 会导致内存使用量为负值。

In the Shuffle component, ShuffleMemoryTracker is used to track the amount of memory used by the Shuffle module, which can be requested using "require" and released using "release".
Currently, there is a "require" and "release" in the Shuffle write end, but there is no "require" in the Shuffle read end. Releasing memory without requiring it will result in a negative memory usage value.

## Solution
当前的 require 行为在 ShardBuffer，release 行为在 OutBuffer，修改为统一在 OutBuffer 内存进行 require 和 release，可以保证初始化时有 require，关闭时有 release。

The current "require" behavior is in ShardBuffer, and the "release" behavior is in OutBuffer. Modifying it to perform "require" and "release" uniformly in the OutBuffer memory can ensure that "require" is performed during initialization and "release" is performed during shutdown.