### PR TITLE
[ISSUE-134] Simplify the static graph semantics in DSL

### DIFF
--- a/geaflow/geaflow-core/geaflow-api/src/main/java/com/antgroup/geaflow/view/graph/GraphViewDesc.java
+++ b/geaflow/geaflow-core/geaflow-api/src/main/java/com/antgroup/geaflow/view/graph/GraphViewDesc.java
@@ -101,4 +101,9 @@ public class GraphViewDesc implements IViewDesc {
             return currentWindowId + currentVersion;
         }
     }
+
+    public GraphViewDesc asStatic() {
+        return new GraphViewDesc(viewName, shardNum, backend, partitioner,
+            graphMetaType, props, 0L);
+    }
 }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/algo/vc/AbstractDynamicGraphVertexCentricOp.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/algo/vc/AbstractDynamicGraphVertexCentricOp.java
@@ -20,10 +20,13 @@ import com.antgroup.geaflow.api.graph.base.algo.VertexCentricAlgo;
 import com.antgroup.geaflow.common.exception.GeaflowRuntimeException;
 import com.antgroup.geaflow.common.utils.CheckpointUtil;
 import com.antgroup.geaflow.model.graph.edge.IEdge;
+import com.antgroup.geaflow.model.graph.meta.GraphMeta;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
 import com.antgroup.geaflow.operator.OpArgs;
 import com.antgroup.geaflow.operator.OpArgs.OpType;
 import com.antgroup.geaflow.operator.impl.graph.compute.dynamic.cache.TemporaryGraphCache;
+import com.antgroup.geaflow.state.DataModel;
+import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
 import com.antgroup.geaflow.view.meta.ViewMetaBookKeeper;
 import java.io.IOException;
@@ -86,6 +89,14 @@ public abstract class AbstractDynamicGraphVertexCentricOp<K, VV, EV, M,
         this.graphMsgBox.clearInBox();
         this.graphMsgBox.clearOutBox();
         this.graphState.manage().operate().close();
+    }
+
+    @Override
+    protected GraphStateDescriptor<K, VV, EV> buildGraphStateDesc(String name) {
+        GraphStateDescriptor<K, VV, EV> desc =  super.buildGraphStateDesc(name);
+        desc.withDataModel(DataModel.DYNAMIC_GRAPH);
+        desc.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
+        return desc;
     }
 
     public GraphViewDesc getGraphViewDesc() {

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/algo/vc/AbstractStaticGraphVertexCentricOp.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/algo/vc/AbstractStaticGraphVertexCentricOp.java
@@ -16,7 +16,10 @@ package com.antgroup.geaflow.operator.impl.graph.algo.vc;
 
 import com.antgroup.geaflow.api.graph.base.algo.VertexCentricAlgo;
 import com.antgroup.geaflow.model.graph.edge.IEdge;
+import com.antgroup.geaflow.model.graph.meta.GraphMeta;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.antgroup.geaflow.state.DataModel;
+import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
 
 import org.slf4j.Logger;
@@ -49,5 +52,15 @@ public abstract class AbstractStaticGraphVertexCentricOp<K, VV, EV, M,
         }
         this.graphState.staticGraph().E().add(edge);
         this.opInputMeter.mark();
+    }
+
+    @Override
+    protected GraphStateDescriptor<K, VV, EV> buildGraphStateDesc(String name) {
+        GraphStateDescriptor<K, VV, EV> desc =  super.buildGraphStateDesc(name);
+        desc.withDataModel(graphViewDesc.isStatic() ? DataModel.STATIC_GRAPH : DataModel.DYNAMIC_GRAPH);
+        if (graphViewDesc.getGraphMetaType() != null) {
+            desc.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
+        }
+        return desc;
     }
 }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/compute/dynamic/DynamicGraphVertexCentricComputeOp.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/compute/dynamic/DynamicGraphVertexCentricComputeOp.java
@@ -20,7 +20,6 @@ import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricComputeFunctio
 import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricComputeFunction.IncGraphComputeContext;
 import com.antgroup.geaflow.collector.ICollector;
 import com.antgroup.geaflow.model.graph.message.DefaultGraphMessage;
-import com.antgroup.geaflow.model.graph.meta.GraphMeta;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
 import com.antgroup.geaflow.model.record.RecordArgs.GraphRecordNames;
 import com.antgroup.geaflow.operator.OpArgs;
@@ -30,8 +29,6 @@ import com.antgroup.geaflow.operator.impl.graph.algo.vc.IGraphVertexCentricOp;
 import com.antgroup.geaflow.operator.impl.graph.algo.vc.context.dynamic.IncGraphContextImpl;
 import com.antgroup.geaflow.operator.impl.graph.algo.vc.msgbox.IGraphMsgBox.MsgProcessFunc;
 import com.antgroup.geaflow.operator.impl.iterator.IteratorOperator;
-import com.antgroup.geaflow.state.DataModel;
-import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
 import java.util.HashSet;
 import java.util.List;
@@ -74,15 +71,6 @@ public class DynamicGraphVertexCentricComputeOp<K, VV, EV, M> extends
             }
         }
     }
-
-    @Override
-    protected GraphStateDescriptor<K, VV, EV> buildGraphStateDesc(String name) {
-        GraphStateDescriptor<K, VV, EV> desc =  super.buildGraphStateDesc(name);
-        desc.withDataModel(DataModel.DYNAMIC_GRAPH);
-        desc.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
-        return desc;
-    }
-
 
     @Override
     public void doFinishIteration(long iterations) {

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/materialize/GraphViewMaterializeOp.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/materialize/GraphViewMaterializeOp.java
@@ -58,7 +58,7 @@ public class GraphViewMaterializeOp<K, VV, EV> extends AbstractOneInputOperator<
         String storeType = graphViewDesc.getBackend().name();
         GraphStateDescriptor<K, VV, EV> descriptor = GraphStateDescriptor.build(
             graphViewDesc.getName(), storeType);
-        descriptor.withDataModel(graphViewDesc.isStatic() ? DataModel.STATIC_GRAPH : DataModel.DYNAMIC_GRAPH);
+        descriptor.withDataModel(DataModel.DYNAMIC_GRAPH);
         descriptor.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
         descriptor.withMetricGroup(runtimeContext.getMetric());
 
@@ -80,11 +80,7 @@ public class GraphViewMaterializeOp<K, VV, EV> extends AbstractOneInputOperator<
             taskIndex, keyGroup);
         this.graphState = StateFactory.buildGraphState(descriptor, runtimeContext.getConfiguration());
         recover();
-        if (graphViewDesc.isStatic()) {
-            this.function =  new StaticGraphMaterializeFunction<>(graphState);
-        } else {
-            this.function = new DynamicGraphMaterializeFunction<>(graphState);
-        }
+        this.function = new DynamicGraphMaterializeFunction<>(graphState);
     }
 
     @Override
@@ -153,25 +149,6 @@ public class GraphViewMaterializeOp<K, VV, EV> extends AbstractOneInputOperator<
                 graphState.manage().operate().setCheckpointId(recoverVersionId);
                 graphState.manage().operate().recover();
             }
-        }
-    }
-
-    private static class StaticGraphMaterializeFunction<K, VV, EV> implements GraphMaterializeFunction<K, VV, EV> {
-
-        private final GraphState<K, VV, EV> graphState;
-
-        public StaticGraphMaterializeFunction(GraphState<K, VV, EV> graphState) {
-            this.graphState = graphState;
-        }
-
-        @Override
-        public void materializeVertex(IVertex<K, VV> vertex) {
-            graphState.staticGraph().V().add(vertex);
-        }
-
-        @Override
-        public void materializeEdge(IEdge<K, EV> edge) {
-            graphState.staticGraph().E().add(edge);
         }
     }
 

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/traversal/dynamic/DynamicGraphVertexCentricTraversalStartByStreamOp.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-operator/src/main/java/com/antgroup/geaflow/operator/impl/graph/traversal/dynamic/DynamicGraphVertexCentricTraversalStartByStreamOp.java
@@ -15,12 +15,7 @@
 package com.antgroup.geaflow.operator.impl.graph.traversal.dynamic;
 
 import com.antgroup.geaflow.api.graph.traversal.IncVertexCentricTraversal;
-import com.antgroup.geaflow.model.traversal.ITraversalRequest;
-import com.antgroup.geaflow.utils.keygroup.KeyGroupAssignment;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,19 +29,5 @@ public class DynamicGraphVertexCentricTraversalStartByStreamOp<K, VV, EV, M, R> 
         GraphViewDesc graphViewDesc,
         IncVertexCentricTraversal<K, VV, EV, M, R> vcTraversal) {
         super(graphViewDesc, vcTraversal);
-    }
-
-    @Override
-    public Iterator<ITraversalRequest<K>> getTraversalRequests() {
-        List<ITraversalRequest<K>> currentTaskRequest = new ArrayList<>();
-        int maxParallelism = graphViewDesc.getShardNum();
-        for (ITraversalRequest<K> traversalRequest : traversalRequests) {
-            int currentKeyGroup = KeyGroupAssignment.assignToKeyGroup(traversalRequest.getVId(),
-                maxParallelism);
-            if (currentKeyGroup >= keyGroup.getStartKeyGroup() && currentKeyGroup <= keyGroup.getEndKeyGroup()) {
-                currentTaskRequest.add(traversalRequest);
-            }
-        }
-        return currentTaskRequest.iterator();
     }
 }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-pdata/src/main/java/com/antgroup/geaflow/pdata/graph/view/IncGraphView.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-pdata/src/main/java/com/antgroup/geaflow/pdata/graph/view/IncGraphView.java
@@ -14,21 +14,18 @@
 
 package com.antgroup.geaflow.pdata.graph.view;
 
-import com.antgroup.geaflow.api.function.internal.CollectionSource;
 import com.antgroup.geaflow.api.graph.PGraphWindow;
 import com.antgroup.geaflow.api.graph.compute.IncVertexCentricCompute;
 import com.antgroup.geaflow.api.graph.compute.PGraphCompute;
 import com.antgroup.geaflow.api.graph.traversal.IncVertexCentricTraversal;
 import com.antgroup.geaflow.api.graph.traversal.PGraphTraversal;
 import com.antgroup.geaflow.api.pdata.stream.window.PWindowStream;
-import com.antgroup.geaflow.api.window.impl.AllWindow;
 import com.antgroup.geaflow.model.graph.edge.IEdge;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
 import com.antgroup.geaflow.pdata.graph.view.compute.ComputeIncGraph;
 import com.antgroup.geaflow.pdata.graph.view.materialize.MaterializedIncGraph;
 import com.antgroup.geaflow.pdata.graph.view.traversal.TraversalIncGraph;
 import com.antgroup.geaflow.pdata.graph.window.WindowStreamGraph;
-import com.antgroup.geaflow.pdata.stream.window.WindowStreamSource;
 import com.antgroup.geaflow.pipeline.context.IPipelineContext;
 import com.antgroup.geaflow.view.IViewDesc;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
@@ -64,12 +61,7 @@ public class IncGraphView<K, VV, EV> implements PIncGraphView<K, VV, EV> {
     @SuppressWarnings("unchecked")
     @Override
     public PGraphWindow<K, VV, EV> snapshot(long version) {
-        PWindowStream vertexSource = new WindowStreamSource(pipelineContext, new CollectionSource(),
-            AllWindow.getInstance());
-        PWindowStream edgeSource = new WindowStreamSource(pipelineContext, new CollectionSource(),
-            AllWindow.getInstance());
-        return new WindowStreamGraph<>(((GraphViewDesc) graphViewDesc).snapshot(version), pipelineContext,
-            vertexSource, edgeSource);
+        return new WindowStreamGraph<>(((GraphViewDesc) graphViewDesc).snapshot(version), pipelineContext);
     }
 
     @Override

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-pdata/src/main/java/com/antgroup/geaflow/pdata/graph/window/WindowStreamGraph.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-pdata/src/main/java/com/antgroup/geaflow/pdata/graph/window/WindowStreamGraph.java
@@ -15,16 +15,19 @@
 package com.antgroup.geaflow.pdata.graph.window;
 
 import com.antgroup.geaflow.api.function.base.KeySelector;
+import com.antgroup.geaflow.api.function.internal.CollectionSource;
 import com.antgroup.geaflow.api.graph.PGraphWindow;
 import com.antgroup.geaflow.api.graph.compute.PGraphCompute;
 import com.antgroup.geaflow.api.graph.compute.VertexCentricCompute;
 import com.antgroup.geaflow.api.graph.traversal.PGraphTraversal;
 import com.antgroup.geaflow.api.graph.traversal.VertexCentricTraversal;
 import com.antgroup.geaflow.api.pdata.stream.window.PWindowStream;
+import com.antgroup.geaflow.api.window.impl.AllWindow;
 import com.antgroup.geaflow.model.graph.edge.IEdge;
 import com.antgroup.geaflow.model.graph.vertex.IVertex;
 import com.antgroup.geaflow.pdata.graph.window.compute.ComputeWindowGraph;
 import com.antgroup.geaflow.pdata.graph.window.traversal.TraversalWindowGraph;
+import com.antgroup.geaflow.pdata.stream.window.WindowStreamSource;
 import com.antgroup.geaflow.pipeline.context.IPipelineContext;
 import com.antgroup.geaflow.view.graph.GraphViewDesc;
 import com.google.common.base.Preconditions;
@@ -41,14 +44,30 @@ public class WindowStreamGraph<K, VV, EV> implements PGraphWindow<K, VV, EV>, Se
     private final PWindowStream<IVertex<K, VV>> vertexWindowSteam;
     private final PWindowStream<IEdge<K, EV>> edgeWindowStream;
 
+    /**
+     * Create a static window graph.
+     */
     public WindowStreamGraph(GraphViewDesc graphViewDesc, IPipelineContext pipelineContext,
                              PWindowStream<IVertex<K, VV>> vertexWindowSteam,
                              PWindowStream<IEdge<K, EV>> edgeWindowStream) {
-        this.graphViewDesc = graphViewDesc;
+        this.graphViewDesc = graphViewDesc.asStatic();
         this.pipelineContext = pipelineContext;
         this.vertexWindowSteam = vertexWindowSteam;
         this.edgeWindowStream =  edgeWindowStream;
     }
+
+    /**
+     * Create a snapshot window graph.
+     */
+    public WindowStreamGraph(GraphViewDesc graphViewDesc, IPipelineContext pipelineContext) {
+        this.graphViewDesc = graphViewDesc;
+        this.pipelineContext = pipelineContext;
+        this.vertexWindowSteam = new WindowStreamSource(pipelineContext, new CollectionSource(),
+            AllWindow.getInstance());
+        this.edgeWindowStream = new WindowStreamSource(pipelineContext, new CollectionSource(),
+            AllWindow.getInstance());
+    }
+
 
     @Override
     public <M> PGraphCompute<K, VV, EV> compute(VertexCentricCompute<K, VV, EV, M> vertexCentricCompute) {

--- a/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/catalog/InstanceCalciteSchema.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/catalog/InstanceCalciteSchema.java
@@ -44,7 +44,20 @@ public class InstanceCalciteSchema implements Schema {
 
     @Override
     public Table getTable(String name) {
-        return catalog.getTable(instanceName, name);
+        //At present, Calcite only has one Table data model.
+        // The Graph data model inherits from the Table data model.
+        // During validator inference, it is impossible to distinguish whether it is a graph or a
+        // table based on identifier. It is necessary to read the catalog separately.
+        Table table;
+        try {
+            table = catalog.getTable(instanceName, name);
+        } catch (Exception e) {
+            table = null;
+        }
+        if (table != null) {
+            return table;
+        }
+        return catalog.getGraph(instanceName, name);
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/catalog/console/CatalogUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/catalog/console/CatalogUtil.java
@@ -203,7 +203,7 @@ public class CatalogUtil {
         }
         GeaFlowGraph geaFlowGraph = new GeaFlowGraph(instanceName, model.getName(), vertexTables,
             edgeTables, convertToGeaFlowGraphConfig(model.getPluginConfig()), Collections.emptyMap(),
-            true, false, false);
+            true, false);
         geaFlowGraph.setDescriptor(geaFlowGraph.getValidDescriptorInGraph(desc));
         return geaFlowGraph;
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraph.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraph.java
@@ -51,15 +51,13 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
     private final List<EdgeTable> edgeTables;
     private final Map<String, String> usingTables;
     private final Map<String, String> config;
-    private boolean isStatic;
     private final boolean ifNotExists;
     private final boolean isTemporary;
     private GraphDescriptor graphDescriptor;
 
     public GeaFlowGraph(String instanceName, String name, List<VertexTable> vertexTables,
                         List<EdgeTable> edgeTables, Map<String, String> config,
-                        Map<String, String> usingTables, boolean ifNotExists,
-                        boolean isStatic, boolean isTemporary) {
+                        Map<String, String> usingTables, boolean ifNotExists, boolean isTemporary) {
         this.instanceName = instanceName;
         this.name = name;
         this.vertexTables = vertexTables;
@@ -75,8 +73,15 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
         for (EdgeTable edgeTable : this.edgeTables) {
             edgeTable.setGraph(this);
         }
-        this.isStatic = isStatic;
         this.validate();
+    }
+
+    public GeaFlowGraph(String instanceName, String name, List<VertexTable> vertexTables,
+                        List<EdgeTable> edgeTables, Map<String, String> config,
+                        Map<String, String> usingTables, boolean ifNotExists, boolean isTemporary,
+                        GraphDescriptor descriptor) {
+        this(instanceName, name, vertexTables, edgeTables, config, usingTables, ifNotExists, isTemporary);
+        this.graphDescriptor = Objects.requireNonNull(descriptor);
     }
 
     public void validate() {
@@ -236,14 +241,6 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
 
     public int getShardCount() {
         return Configuration.getInteger(DSLConfigKeys.GEAFLOW_DSL_STORE_SHARD_COUNT, config);
-    }
-
-    public boolean isStatic() {
-        return isStatic;
-    }
-
-    public void setStatic(boolean aStatic) {
-        isStatic = aStatic;
     }
 
     public IType<?> getIdType() {

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/planner/GQLContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/planner/GQLContext.java
@@ -52,7 +52,6 @@ import com.antgroup.geaflow.dsl.util.SqlTypeUtil;
 import com.antgroup.geaflow.dsl.util.StringLiteralUtil;
 import com.antgroup.geaflow.dsl.validator.GQLValidatorImpl;
 import com.antgroup.geaflow.dsl.validator.QueryNodeContext;
-import com.antgroup.geaflow.state.StoreType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -317,7 +316,6 @@ public class GQLContext {
                                        Configuration globalConfiguration) {
         List<VertexTable> vertexTables = new ArrayList<>();
         SqlNodeList vertices = graph.getVertices();
-        boolean isAllVertexEdgeStatic = true;
         Map<String, String> vertexEdgeName2UsingTableNameMap = new HashMap<>();
 
         GraphDescriptor desc = new GraphDescriptor();
@@ -341,7 +339,6 @@ public class GQLContext {
                                 + " at " + tableColumn.getParserPosition());
                     }
                 }
-                isAllVertexEdgeStatic = false;
                 vertexTables.add(new VertexTable(vertex.getName().getSimple(), vertexFields, idFieldName));
                 desc.addNode(new NodeDescriptor(desc.getIdName(graph.getName().toString()),
                     vertex.getName().getSimple()));
@@ -384,9 +381,6 @@ public class GQLContext {
                     throw new GeaFlowDSLException("Cannot found srcIdFieldName: {} in vertex {}",
                         idFieldName, vertexUsing.getName().getSimple());
                 }
-
-                isAllVertexEdgeStatic &= (usingTable instanceof GeaFlowTable)
-                    && ((GeaFlowTable)usingTable).isAllWindow(globalConfiguration);
                 vertexEdgeName2UsingTableNameMap.put(vertexUsing.getName().getSimple(),
                     vertexUsing.getUsingTableName().getSimple());
                 vertexTables.add(new VertexTable(vertexUsing.getName().getSimple(), vertexFields, idFieldName));
@@ -442,7 +436,6 @@ public class GQLContext {
                                 + " at " + tableColumn.getParserPosition());
                     }
                 }
-                isAllVertexEdgeStatic = false;
                 String tableName = edge.getName().getSimple();
                 edgeTables.add(new EdgeTable(tableName, edgeFields, srcIdFieldName, targetIdFieldName, tsFieldName));
                 desc.addEdge(GraphDescriptorUtil.getEdgeDescriptor(desc, graph.getName().getSimple(), edge));
@@ -501,9 +494,6 @@ public class GQLContext {
                     throw new GeaFlowDSLException("Cannot found tsFieldName: {} in edge {}",
                         tsFieldName, edgeUsing.getName().getSimple());
                 }
-
-                isAllVertexEdgeStatic &= (usingTable instanceof GeaFlowTable)
-                    && ((GeaFlowTable)usingTable).isAllWindow(globalConfiguration);
                 vertexEdgeName2UsingTableNameMap.put(edgeUsing.getName().getSimple(),
                     edgeUsing.getUsingTableName().getSimple());
                 edgeTables.add(new EdgeTable(edgeUsing.getName().getSimple(), edgeFields,
@@ -522,11 +512,9 @@ public class GQLContext {
                 config.put(key, value);
             }
         }
-        boolean isStaticGraph = isAllVertexEdgeStatic || config.getOrDefault(DSLConfigKeys.GEAFLOW_DSL_STORE_TYPE.getKey(),
-            StoreType.MEMORY.name()).equalsIgnoreCase(StoreType.MEMORY.name());
         GeaFlowGraph geaFlowGraph = new GeaFlowGraph(currentInstance, graph.getName().getSimple(),
             vertexTables, edgeTables, config, vertexEdgeName2UsingTableNameMap, graph.ifNotExists(),
-            isStaticGraph, graph.isTemporary()).setDescriptor(desc);
+            graph.isTemporary(), desc);
         GraphDescriptor graphStats = geaFlowGraph.getValidDescriptorInGraph(desc);
         if (graphStats.nodes.size() != desc.nodes.size()
             || graphStats.edges.size() != desc.edges.size()

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/catalog/CatalogTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/catalog/CatalogTest.java
@@ -33,7 +33,7 @@ public class CatalogTest {
         Catalog catalog = CatalogFactory.getCatalog(new Configuration());
         String instance = "default";
         GeaFlowGraph graph = new GeaFlowGraph(instance, "g1", new ArrayList<>(),
-            new ArrayList<>(), new HashMap<>(), new HashMap<>(), true, false, false);
+            new ArrayList<>(), new HashMap<>(), new HashMap<>(), true, false);
         GeaFlowTable table = new GeaFlowTable(instance, "t1", new ArrayList<>(),
             new ArrayList<>(), new ArrayList<>(), new HashMap<>(), true, false);
         GeaFlowView view = new GeaFlowView(instance, "v1", new ArrayList<>(),
@@ -68,7 +68,7 @@ public class CatalogTest {
         }
         try {
             GeaFlowGraph graph2 = new GeaFlowGraph(instance, "g2", new ArrayList<>(),
-                new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false, false);
+                new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false);
             catalog.createGraph(instance, graph2);
             catalog.createGraph(instance, graph2);
         } catch (Exception e) {

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraphTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraphTest.java
@@ -70,8 +70,7 @@ public class GeaFlowGraphTest {
             Lists.newArrayList(vertexTable),
             Lists.newArrayList(edgeTable),
             config, new HashMap<>(),
-            false, false, false
-        );
+            false, false);
 
         RelDataType relDataType = graph.getRowType(typeFactory);
         assertEquals(relDataType.toString(), "Graph:RecordType:peek("

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/SchemaUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/SchemaUtil.java
@@ -87,14 +87,8 @@ public class SchemaUtil {
     private static long getGraphLatestVersion(GeaFlowGraph graph, Configuration conf) {
         try {
             Configuration globalConfig = graph.getConfigWithGlobal(conf);
-            long lastCheckPointId;
-            if (graph.isStatic()) {
-                lastCheckPointId = 0L;
-            } else {
-                ViewMetaBookKeeper keeper = new ViewMetaBookKeeper(graph.getUniqueName(), globalConfig);
-                lastCheckPointId = keeper.getLatestViewVersion(graph.getUniqueName());
-            }
-            return lastCheckPointId;
+            ViewMetaBookKeeper keeper = new ViewMetaBookKeeper(graph.getUniqueName(), globalConfig);
+            return keeper.getLatestViewVersion(graph.getUniqueName());
         } catch (IOException e) {
             throw new GeaFlowDSLException(e);
         }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/plan/DagTopologyGroupTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/plan/DagTopologyGroupTest.java
@@ -141,7 +141,7 @@ public class DagTopologyGroupTest {
 
     private GraphSchema createGraph() {
         GeaFlowGraph graph = new GeaFlowGraph("default", "test", new ArrayList<>(),
-            new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false, false);
+            new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false);
         GraphRecordType graphRecordType = (GraphRecordType) graph.getRowType(GQLJavaTypeFactory.create());
         return (GraphSchema) SqlTypeUtil.convertType(graphRecordType);
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/plan/StepPlanTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/plan/StepPlanTest.java
@@ -176,7 +176,7 @@ public class StepPlanTest {
         TableField idField = new TableField("id", Types.of("Long"), false);
         VertexTable vTable = new VertexTable("testV", Collections.singletonList(idField),"id");
         GeaFlowGraph graph = new GeaFlowGraph("default", "test", Lists.newArrayList(vTable),
-            new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false, false);
+            new ArrayList<>(), new HashMap<>(), new HashMap<>(), false, false);
         GraphRecordType graphRecordType = (GraphRecordType) graph.getRowType(GQLJavaTypeFactory.create());
         return (GraphSchema) SqlTypeUtil.convertType(graphRecordType);
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/GQLInsertTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/GQLInsertTest.java
@@ -14,6 +14,7 @@
 
 package com.antgroup.geaflow.dsl.runtime.query;
 
+import com.antgroup.geaflow.common.config.keys.FrameworkConfigKeys;
 import org.testng.annotations.Test;
 
 public class GQLInsertTest {
@@ -32,6 +33,17 @@ public class GQLInsertTest {
         QueryTester
             .build()
             .withQueryPath("/query/gql_insert_and_graph_002.sql")
+            .execute()
+            .checkSinkResult();
+    }
+
+    @Test
+    public void testInsertAndQuery_003() throws Exception {
+        QueryTester
+            .build()
+            .enableInitDDL(false)
+            .withConfig(FrameworkConfigKeys.BATCH_NUMBER_PER_CHECKPOINT.getKey(), "2")
+            .withQueryPath("/query/gql_insert_and_graph_003.sql")
             .execute()
             .checkSinkResult();
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/expect/gql_insert_and_graph_003.txt
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/expect/gql_insert_and_graph_003.txt
@@ -1,0 +1,7 @@
+1,marko,29
+2,vadas,27
+4,josh,32
+1,marko,29
+2,vadas,27
+4,josh,32
+6,peter,35

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/gql_insert_and_graph_003.sql
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/gql_insert_and_graph_003.sql
@@ -1,0 +1,56 @@
+set geaflow.dsl.window.size = 3;
+
+CREATE GRAPH dy_modern (
+	Vertex person (
+	  id bigint ID,
+	  name varchar,
+	  age int
+	),
+	Vertex software (
+	  id bigint ID,
+	  name varchar,
+	  lang varchar
+	),
+	Edge knows (
+	  srcId bigint SOURCE ID,
+	  targetId bigint DESTINATION ID,
+	  weight double
+	),
+	Edge created (
+	  srcId bigint SOURCE ID,
+  	targetId bigint DESTINATION ID,
+  	weight double
+	)
+) WITH (
+	storeType='memory',
+	shardCount = 1
+);
+
+CREATE TABLE tbl_result (
+	id bigint,
+	name varchar,
+	age int
+) WITH (
+	type='file',
+	geaflow.dsl.file.path='${target}'
+);
+
+CREATE TABLE tbl_person (
+	id bigint,
+	name varchar,
+	age int
+) WITH (
+	type='file',
+	geaflow.dsl.file.path='resource:///data/modern_vertex_person.txt'
+);
+
+USE GRAPH dy_modern;
+
+INSERT INTO dy_modern.person(id, name, age)
+SELECT * FROM tbl_person;
+;
+
+INSERT INTO tbl_result
+MATCH (a:person)
+RETURN a.id, a.name, a.age
+;

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/allshortestpath/AllShortestPath.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/allshortestpath/AllShortestPath.java
@@ -97,7 +97,7 @@ public class AllShortestPath {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Map<String, Object>>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/closenesscentrality/ClosenessCentrality.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/closenesscentrality/ClosenessCentrality.java
@@ -88,7 +88,7 @@ public class ClosenessCentrality {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Tuple<Double, Integer>>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/clustercoefficient/ClusterCoefficient.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/clustercoefficient/ClusterCoefficient.java
@@ -87,7 +87,7 @@ public class ClusterCoefficient {
                 pipelineTaskCxt.buildSource(eSource, AllWindow.getInstance()).withParallelism(sourceParallelism);
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Double>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/commonneighbors/CommonNeighbors.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/commonneighbors/CommonNeighbors.java
@@ -86,7 +86,7 @@ public class CommonNeighbors {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Integer>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/kcore/KCore.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/kcore/KCore.java
@@ -88,7 +88,7 @@ public class KCore {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Boolean>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/labelpropagation/LabelPropagation.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/labelpropagation/LabelPropagation.java
@@ -87,7 +87,7 @@ public class LabelPropagation {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Integer>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/linkprediction/LinkPrediction.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/linkprediction/LinkPrediction.java
@@ -87,7 +87,7 @@ public class LinkPrediction {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Double>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/npaths/NPaths.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/npaths/NPaths.java
@@ -95,7 +95,7 @@ public class NPaths {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Map<String, String>>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/pagerank/PageRank.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/pagerank/PageRank.java
@@ -91,7 +91,7 @@ public class PageRank {
             int iterationParallelism = conf.getInteger(ExampleConfigKeys.ITERATOR_PARALLELISM);
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PGraphWindow<Integer, Double, Integer> graphWindow =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/personalrank/PersonalRank.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/personalrank/PersonalRank.java
@@ -108,7 +108,7 @@ public class PersonalRank {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PGraphWindow<Integer, Double, Integer> graphWindow =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/shortestpath/ShortestPath.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/shortestpath/ShortestPath.java
@@ -94,7 +94,7 @@ public class ShortestPath {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Map<String, String>>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/shortestpathofvertexsets/ShortestPathOfVertexSet.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/shortestpathofvertexsets/ShortestPathOfVertexSet.java
@@ -23,7 +23,6 @@ import com.antgroup.geaflow.api.window.impl.AllWindow;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.common.tuple.Triple;
 import com.antgroup.geaflow.env.Environment;
-import com.antgroup.geaflow.env.ctx.EnvironmentContext;
 import com.antgroup.geaflow.example.config.ExampleConfigKeys;
 import com.antgroup.geaflow.example.data.GraphDataSet;
 import com.antgroup.geaflow.example.function.AbstractVcFunc;
@@ -76,7 +75,7 @@ public class ShortestPathOfVertexSet {
 
     public static IPipelineResult submit(Environment environment) {
         ResultValidator.cleanResult(RESULT_FILE_DIR);
-        Configuration envConfig = ((EnvironmentContext) environment.getEnvironmentContext()).getConfig();
+        Configuration envConfig = environment.getEnvironmentContext().getConfig();
         envConfig.put(FileSink.OUTPUT_DIR, RESULT_FILE_DIR);
 
         Pipeline pipeline = PipelineFactory.buildPipeline(environment);
@@ -99,7 +98,7 @@ public class ShortestPathOfVertexSet {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Map<String, Map<Integer, Object>>>> result =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/sssp/SSSP.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/sssp/SSSP.java
@@ -23,7 +23,6 @@ import com.antgroup.geaflow.api.pdata.stream.window.PWindowSource;
 import com.antgroup.geaflow.api.window.impl.AllWindow;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.env.Environment;
-import com.antgroup.geaflow.env.ctx.EnvironmentContext;
 import com.antgroup.geaflow.example.config.ExampleConfigKeys;
 import com.antgroup.geaflow.example.function.AbstractVcFunc;
 import com.antgroup.geaflow.example.function.FileSink;
@@ -65,7 +64,7 @@ public class SSSP {
 
     public static IPipelineResult submit(Environment environment) {
         Pipeline pipeline = PipelineFactory.buildPipeline(environment);
-        Configuration envConfig = ((EnvironmentContext) environment.getEnvironmentContext()).getConfig();
+        Configuration envConfig = environment.getEnvironmentContext().getConfig();
         envConfig.getConfigMap().put(FileSink.OUTPUT_DIR, RESULT_FILE_PATH);
         ResultValidator.cleanResult(RESULT_FILE_PATH);
 
@@ -92,7 +91,7 @@ public class SSSP {
             int iterationParallelism = conf.getInteger(ExampleConfigKeys.ITERATOR_PARALLELISM);
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PGraphWindow<Integer, Integer, Integer> graphWindow =

--- a/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/weakconnectedcomponents/WeakConnectedComponents.java
+++ b/geaflow/geaflow-examples/src/main/java/com/antgroup/geaflow/example/graph/statical/compute/weakconnectedcomponents/WeakConnectedComponents.java
@@ -88,7 +88,7 @@ public class WeakConnectedComponents {
 
             GraphViewDesc graphViewDesc = GraphViewBuilder
                 .createGraphView(GraphViewBuilder.DEFAULT_GRAPH)
-                .withShardNum(2)
+                .withShardNum(iterationParallelism)
                 .withBackend(BackendType.Memory)
                 .build();
             PWindowStream<IVertex<Integer, Integer>> result =

--- a/geaflow/geaflow-examples/src/test/java/com/antgroup/geaflow/example/graph/GraphAlgorithmsTest.java
+++ b/geaflow/geaflow-examples/src/test/java/com/antgroup/geaflow/example/graph/GraphAlgorithmsTest.java
@@ -48,7 +48,7 @@ public class GraphAlgorithmsTest extends BaseTest {
     private static final Map<String, String> TEST_CONFIG = new HashMap<>();
     static {
         TEST_CONFIG.put(ExampleConfigKeys.SOURCE_PARALLELISM.getKey(), String.valueOf(3));
-        TEST_CONFIG.put(ExampleConfigKeys.ITERATOR_PARALLELISM.getKey(), String.valueOf(7));
+        TEST_CONFIG.put(ExampleConfigKeys.ITERATOR_PARALLELISM.getKey(), String.valueOf(4));
         TEST_CONFIG.put(ExampleConfigKeys.SINK_PARALLELISM.getKey(), String.valueOf(5));
         TEST_CONFIG.put(ExampleConfigKeys.GEAFLOW_SINK_TYPE.getKey(), SinkType.FILE_SINK.name());
     }
@@ -188,7 +188,7 @@ public class GraphAlgorithmsTest extends BaseTest {
     @Test
     public void personalRankTest() throws Exception {
         environment = EnvironmentFactory.onLocalEnvironment();
-        Configuration config = ((EnvironmentContext) environment.getEnvironmentContext()).getConfig();
+        Configuration config = environment.getEnvironmentContext().getConfig();
         config.putAll(TEST_CONFIG);
 
         IPipelineResult result = PersonalRank.submit(environment);
@@ -201,7 +201,7 @@ public class GraphAlgorithmsTest extends BaseTest {
     @Test
     public void shortestPathTest() throws Exception {
         environment = EnvironmentFactory.onLocalEnvironment();
-        Configuration config = ((EnvironmentContext) environment.getEnvironmentContext()).getConfig();
+        Configuration config = environment.getEnvironmentContext().getConfig();
         config.putAll(TEST_CONFIG);
 
         IPipelineResult result = ShortestPath.submit(environment);
@@ -227,7 +227,7 @@ public class GraphAlgorithmsTest extends BaseTest {
     @Test
     public void SSSPTest() throws Exception {
         environment = EnvironmentFactory.onLocalEnvironment();
-        Configuration config = ((EnvironmentContext) environment.getEnvironmentContext()).getConfig();
+        Configuration config = environment.getEnvironmentContext().getConfig();
         config.putAll(TEST_CONFIG);
 
         IPipelineResult result = SSSP.submit(environment);


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current DSL supports two types of semantics, static graph and dynamic graph, which can easily confuse users. For simplicity, it is necessary to simplify and unify the static graph semantics.
Firstly, for a given vertex-edge stream that forms a graph using PStreams, it is considered a static graph, which is only stored in memory.
Secondly, when querying a snapshot of the dynamic graph at a specific moment, although the graph itself is dynamic, the computation is performed statically on the snapshot.
Except for these two cases, all other graphs are considered dynamic graphs.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
