### PR TITLE
[ISSUE-139] Fix  NPE for UDGA when the target vertex  is not exist

### DIFF
--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmDynamicTraversalFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmDynamicTraversalFunction.java
@@ -66,8 +66,11 @@ public class GeaFlowAlgorithmDynamicTraversalFunction
         Object vertexId = traversalRequest.getVId();
         algorithmCtx.setVertexId(vertexId);
         RowVertex vertex = (RowVertex) algorithmCtx.loadVertex();
-        algorithmCtx.setVertexId(vertex.getId());
-        userFunction.process(vertex, Collections.emptyIterator());
+        if (vertex != null) {
+            algorithmCtx.setVertexId(vertex.getId());
+            userFunction.process(vertex, Collections.emptyIterator());
+        }
+
     }
 
     @Override
@@ -88,22 +91,26 @@ public class GeaFlowAlgorithmDynamicTraversalFunction
     public void compute(Object vertexId, Iterator<Object> messages) {
         algorithmCtx.setVertexId(vertexId);
         RowVertex vertex = (RowVertex) algorithmCtx.loadVertex();
-        Row newValue = algorithmCtx.getVertexNewValue();
-        if (newValue != null) {
-            vertex.setValue(newValue);
+        if (vertex != null) {
+            Row newValue = algorithmCtx.getVertexNewValue();
+            if (newValue != null) {
+                vertex.setValue(newValue);
+            }
+            userFunction.process(vertex, messages);
         }
-        userFunction.process(vertex, messages);
     }
 
     @Override
     public void finish(Object vertexId, MutableGraph<Object, Row, Row> mutableGraph) {
         algorithmCtx.setVertexId(vertexId);
         RowVertex rowVertex = (RowVertex) algorithmCtx.loadVertex();
-        Row newValue = algorithmCtx.getVertexNewValue();
-        if (newValue != null) {
-            rowVertex.setValue(newValue);
+        if (rowVertex != null) {
+            Row newValue = algorithmCtx.getVertexNewValue();
+            if (newValue != null) {
+                rowVertex.setValue(newValue);
+            }
+            userFunction.finish(rowVertex);
         }
-        userFunction.finish(rowVertex);
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmTraversalFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmTraversalFunction.java
@@ -55,19 +55,23 @@ public class GeaFlowAlgorithmTraversalFunction implements
     @Override
     public void init(ITraversalRequest<Object> traversalRequest) {
         RowVertex vertex = (RowVertex) traversalContext.vertex().get();
-        algorithmCtx.setVertexId(vertex.getId());
-        userFunction.process(vertex, Collections.emptyIterator());
+        if (vertex != null) {
+            algorithmCtx.setVertexId(vertex.getId());
+            userFunction.process(vertex, Collections.emptyIterator());
+        }
     }
 
     @Override
     public void compute(Object vertexId, Iterator<Object> messages) {
         algorithmCtx.setVertexId(vertexId);
         RowVertex vertex = (RowVertex) traversalContext.vertex().get();
-        Row newValue = algorithmCtx.getVertexNewValue();
-        if (newValue != null) {
-            vertex.setValue(newValue);
+        if (vertex != null) {
+            Row newValue = algorithmCtx.getVertexNewValue();
+            if (newValue != null) {
+                vertex.setValue(newValue);
+            }
+            userFunction.process(vertex, messages);
         }
-        userFunction.process(vertex, messages);
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/MatchVertexOperator.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/MatchVertexOperator.java
@@ -91,11 +91,13 @@ public class MatchVertexOperator extends AbstractStepOperator<MatchVertexFunctio
             Object targetId = edge.getTargetId();
             // load targetId.
             RowVertex vertex = context.loadVertex(targetId, function.getVertexFilter(), graphSchema, addingVertexFieldTypes);
-            ITreePath treePath = edgeGroupRecord.getPathById(targetId);
-            // set current vertex.
-            context.setVertex(vertex);
-            // process new vertex.
-            processVertex(VertexRecord.of(vertex, treePath));
+            if (vertex != null) {
+                ITreePath treePath = edgeGroupRecord.getPathById(targetId);
+                // set current vertex.
+                context.setVertex(vertex);
+                // process new vertex.
+                processVertex(VertexRecord.of(vertex, treePath));
+            }
         }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In dynamic graph algorithms, the process() method is called without considering whether the vertices exist. If a vertex has not yet been inserted into the graph and is accessed, it will cause an NPE (NullPointerException), such as when accessing the endpoint of an edge. It is necessary to add null check logic to skip the target vertex that is null.

### How was this PR tested?
- [x] Tests have Added for the changes
- [ ] Production environment verified
