### PR TITLE
[ISSUE-158] JDBC connector cannot write data into mysql database

### DIFF
--- a/geaflow/geaflow-dsl/geaflow-dsl-connector/geaflow-dsl-connector-jdbc/src/main/java/com/antgroup/geaflow/dsl/connector/jdbc/JDBCTableSink.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-connector/geaflow-dsl-connector-jdbc/src/main/java/com/antgroup/geaflow/dsl/connector/jdbc/JDBCTableSink.java
@@ -63,7 +63,6 @@ public class JDBCTableSink implements TableSink {
             this.connection = DriverManager.getConnection(url, username, password);
             this.connection.setAutoCommit(false);
             this.statement = connection.createStatement();
-            JDBCUtils.createTemporaryTable(statement, this.tableName, this.schema.getFields());
         } catch (Exception e) {
             throw new GeaFlowDSLException("failed to connect to database", e);
         }

--- a/geaflow/geaflow-dsl/geaflow-dsl-connector/geaflow-dsl-connector-jdbc/src/test/java/com/antgroup/geaflow/dsl/connector/jdbc/JDBCTableConnectorTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-connector/geaflow-dsl-connector-jdbc/src/test/java/com/antgroup/geaflow/dsl/connector/jdbc/JDBCTableConnectorTest.java
@@ -47,10 +47,10 @@ public class JDBCTableConnectorTest {
         LOGGER.info("start h2 database.");
         JdbcDataSource dataSource = new JdbcDataSource();
         dataSource.setURL(URL);
-        dataSource.setURL(username);
+        dataSource.setUser(username);
         dataSource.setPassword(password);
 
-        connection = DriverManager.getConnection(URL);
+        connection = java.sql.DriverManager.getConnection(URL);
         statement = connection.createStatement();
         statement.execute("CREATE TABLE test_table (id INT PRIMARY KEY, name VARCHAR(255))");
         statement.execute("INSERT INTO test_table (id, name) VALUES (1, 'Test1')");

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/JDBCTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/JDBCTest.java
@@ -16,7 +16,6 @@ package com.antgroup.geaflow.dsl.runtime.query;
 
 import com.antgroup.geaflow.common.config.keys.DSLConfigKeys;
 import com.antgroup.geaflow.dsl.runtime.testenv.SourceFunctionNoPartitionCheck;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
@@ -42,7 +41,7 @@ public class JDBCTest {
         dataSource.setUser(username);
         dataSource.setPassword(password);
 
-        Statement statement = DriverManager.getConnection(URL).createStatement();
+        Statement statement = dataSource.getConnection().createStatement();
         statement.execute("CREATE TABLE test (name VARCHAR(255) primary key, count INT);");
         statement.execute("CREATE TABLE users (id INT primary key, name VARCHAR(255), age INT);");
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/JDBCTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/JDBCTest.java
@@ -16,12 +16,15 @@ package com.antgroup.geaflow.dsl.runtime.query;
 
 import com.antgroup.geaflow.common.config.keys.DSLConfigKeys;
 import com.antgroup.geaflow.dsl.runtime.testenv.SourceFunctionNoPartitionCheck;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JDBCTest {
@@ -32,12 +35,16 @@ public class JDBCTest {
     private final String password = "h2_pwd";
 
     @BeforeClass
-    public void setup() {
+    public void setup() throws SQLException {
         LOGGER.info("start h2 database.");
         JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL(this.URL);
-        dataSource.setURL(this.username);
-        dataSource.setPassword(this.password);
+        dataSource.setURL(URL);
+        dataSource.setUser(username);
+        dataSource.setPassword(password);
+
+        Statement statement = DriverManager.getConnection(URL).createStatement();
+        statement.execute("CREATE TABLE test (name VARCHAR(255) primary key, count INT);");
+        statement.execute("CREATE TABLE users (id INT primary key, name VARCHAR(255), age INT);");
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
 After using the JDBC Connector to connect to MYSQL for writing, the job runs successfully but the data is not written to the database. The reason is that the Sink implementation creates a temporary table, causing the data to be written into the temporary table.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
