### PR TITLE
[ISSUE-164] Add keyby for sink table with primary key

### DIFF
--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/project_006.sql
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/project_006.sql
@@ -9,9 +9,10 @@ CREATE TABLE users (
 );
 
 CREATE TABLE output_console(
-	console_f1 bigint,
+	id bigint,
 	console_f2 double,
-	console_f3 varchar
+	console_f3 varchar,
+	PRIMARY KEY(id)
 ) WITH (
 	type='file',
 	geaflow.dsl.file.path='${target}'


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->
For sink table with primary key, e.g. mysql, we need do data shuffle by the primary key before write data to the sink table.
If not do this,  write conflict will happen on the same primary key when  different task update data to the same key.
### How was this PR tested?
- [x] Tests have Added for the changes
- [ ] Production environment verified
