### PR TITLE
[ISSUE-171] DSL Supports  early termination for Traversal and Algorithm execution

### DIFF
--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/planner/GQLContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/planner/GQLContext.java
@@ -304,16 +304,11 @@ public class GQLContext {
      * Convert {@link SqlCreateGraph} to {@link GeaFlowGraph}.
      */
     public GeaFlowGraph convertToGraph(SqlCreateGraph graph) {
-        return convertToGraph(graph, Collections.emptyList(), new Configuration());
-    }
-
-    public GeaFlowGraph convertToGraph(SqlCreateGraph graph, Configuration globalConfiguration) {
-        return convertToGraph(graph, Collections.emptyList(), globalConfiguration);
+        return convertToGraph(graph, Collections.emptyList());
     }
 
     public GeaFlowGraph convertToGraph(SqlCreateGraph graph,
-                                       Collection<GeaFlowTable> createTablesInScript,
-                                       Configuration globalConfiguration) {
+                                       Collection<GeaFlowTable> createTablesInScript) {
         List<VertexTable> vertexTables = new ArrayList<>();
         SqlNodeList vertices = graph.getVertices();
         Map<String, String> vertexEdgeName2UsingTableNameMap = new HashMap<>();

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/command/CreateGraphCommand.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/command/CreateGraphCommand.java
@@ -59,7 +59,7 @@ public class CreateGraphCommand implements IQueryCommand {
     @Override
     public QueryResult execute(QueryContext context) {
         GQLContext gContext = context.getGqlContext();
-        GeaFlowGraph graph = gContext.convertToGraph(createGraph, context.getGlobalConf());
+        GeaFlowGraph graph = gContext.convertToGraph(createGraph);
         gContext.registerGraph(graph);
         processUsing(graph, context);
         LOGGER.info("Succeed to create graph: {}.", graph);
@@ -68,6 +68,7 @@ public class CreateGraphCommand implements IQueryCommand {
 
 
     private void processUsing(GeaFlowGraph graph, QueryContext context) {
+
         //Graph first time creation will trigger insert operations
         if (!QueryUtil.isGraphExists(graph, graph.getConfigWithGlobal(context.getGlobalConf()))) {
             //Convert graph construction using tables to equivalent insert statement

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/AbstractTraversalRuntimeContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/AbstractTraversalRuntimeContext.java
@@ -14,6 +14,7 @@
 
 package com.antgroup.geaflow.dsl.runtime.engine;
 
+import com.antgroup.geaflow.api.graph.function.aggregate.VertexCentricAggContextFunction.VertexCentricAggContext;
 import com.antgroup.geaflow.api.graph.function.vc.VertexCentricTraversalFunction.TraversalEdgeQuery;
 import com.antgroup.geaflow.api.graph.function.vc.VertexCentricTraversalFunction.TraversalVertexQuery;
 import com.antgroup.geaflow.common.type.IType;
@@ -30,6 +31,7 @@ import com.antgroup.geaflow.dsl.runtime.traversal.data.CallRequestId;
 import com.antgroup.geaflow.dsl.runtime.traversal.data.EdgeGroup;
 import com.antgroup.geaflow.dsl.runtime.traversal.data.ParameterRequest;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.IMessage;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageType;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.ParameterRequestMessage;
@@ -43,6 +45,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 
@@ -70,6 +73,8 @@ public abstract class AbstractTraversalRuntimeContext implements TraversalRuntim
     private final Set<CallRequestId> callRequestIds = new HashSet<>();
 
     private final Map<Object, Object[]> vertexId2AppendFields = new HashMap<>();
+
+    protected VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext;
 
     public AbstractTraversalRuntimeContext(TraversalVertexQuery<Object, Row> vertexQuery,
                                            TraversalEdgeQuery<Object, Row> edgeQuery) {
@@ -319,5 +324,15 @@ public abstract class AbstractTraversalRuntimeContext implements TraversalRuntim
     @Override
     public MetricGroup getMetric() {
         return getRuntimeContext().getMetric();
+    }
+
+    @Override
+    public VertexCentricAggContext<ITraversalAgg, ITraversalAgg> getAggContext() {
+        return aggContext;
+    }
+
+    @Override
+    public void setAggContext(VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext) {
+        this.aggContext = Objects.requireNonNull(aggContext);
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmRuntimeContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowAlgorithmRuntimeContext.java
@@ -14,6 +14,7 @@
 
 package com.antgroup.geaflow.dsl.runtime.engine;
 
+import com.antgroup.geaflow.api.graph.function.aggregate.VertexCentricAggContextFunction.VertexCentricAggContext;
 import com.antgroup.geaflow.api.graph.function.vc.VertexCentricTraversalFunction.TraversalEdgeQuery;
 import com.antgroup.geaflow.api.graph.function.vc.VertexCentricTraversalFunction.VertexCentricTraversalFuncContext;
 import com.antgroup.geaflow.dsl.common.algo.AlgorithmRuntimeContext;
@@ -21,6 +22,7 @@ import com.antgroup.geaflow.dsl.common.data.Row;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
 import com.antgroup.geaflow.dsl.common.types.GraphSchema;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
 import com.antgroup.geaflow.model.graph.edge.EdgeDirection;
 import com.antgroup.geaflow.model.traversal.ITraversalResponse;
 import com.antgroup.geaflow.model.traversal.TraversalType.ResponseType;
@@ -28,15 +30,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class GeaFlowAlgorithmRuntimeContext implements AlgorithmRuntimeContext<Object, Object> {
 
     private final VertexCentricTraversalFuncContext<Object, Row, Row, Object, Row> traversalContext;
 
+    protected VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext;
+
     private final GraphSchema graphSchema;
     private final TraversalEdgeQuery<Object, Row> edgeQuery;
 
     private Object vertexId;
+
+    private long lastSendAggMsgIterationId = -1L;
 
     private final Map<Object, Row> vertexId2NewValue = new HashMap<>();
 
@@ -46,6 +53,7 @@ public class GeaFlowAlgorithmRuntimeContext implements AlgorithmRuntimeContext<O
         this.traversalContext = traversalContext;
         this.edgeQuery = traversalContext.edges();
         this.graphSchema = graphSchema;
+        this.aggContext = null;
     }
 
     public void setVertexId(Object vertexId) {
@@ -74,6 +82,11 @@ public class GeaFlowAlgorithmRuntimeContext implements AlgorithmRuntimeContext<O
     @Override
     public void sendMessage(Object vertexId, Object message) {
         traversalContext.sendMessage(vertexId, message);
+        if (getCurrentIterationId() > lastSendAggMsgIterationId) {
+            lastSendAggMsgIterationId = getCurrentIterationId();
+            aggContext.aggregate(GeaFlowKVAlgorithmAggregateFunction.getAlgorithmAgg(
+                lastSendAggMsgIterationId));
+        }
     }
 
     @Override
@@ -97,6 +110,14 @@ public class GeaFlowAlgorithmRuntimeContext implements AlgorithmRuntimeContext<O
     @Override
     public GraphSchema getGraphSchema() {
         return graphSchema;
+    }
+
+    public VertexCentricAggContext<ITraversalAgg, ITraversalAgg> getAggContext() {
+        return aggContext;
+    }
+
+    public void setAggContext(VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext) {
+        this.aggContext = Objects.requireNonNull(aggContext);
     }
 
     private static class AlgorithmResponse implements ITraversalResponse<Row> {

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicTraversalRuntimeContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicTraversalRuntimeContext.java
@@ -19,11 +19,16 @@ import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricTraversalFunct
 import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricTraversalFunction.TraversalGraphSnapShot;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.KVTraversalAgg;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
 import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
 import com.antgroup.geaflow.model.graph.message.DefaultGraphMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GeaFlowDynamicTraversalRuntimeContext extends AbstractTraversalRuntimeContext {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeaFlowDynamicTraversalRuntimeContext.class);
 
     private final IncVertexCentricTraversalFuncContext<Object, Row, Row, MessageBox, ITreePath> incVCTraversalCtx;
 
@@ -63,7 +68,11 @@ public class GeaFlowDynamicTraversalRuntimeContext extends AbstractTraversalRunt
 
     @Override
     public void sendCoordinator(String name, Object value) {
-
+        LOGGER.info("task: {} send to coordinator {}:{} isAggTraversal:{}", getTaskIndex(), name,
+            value, aggContext != null);
+        if (aggContext != null) {
+            aggContext.aggregate(new KVTraversalAgg(name, value));
+        }
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicVCAggTraversal.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicVCAggTraversal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricAggTraversalFunction;
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricAggregateFunction;
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricCombineFunction;
+import com.antgroup.geaflow.api.graph.traversal.IncVertexCentricAggTraversal;
+import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.ExecuteDagGroup;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
+import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
+
+public class GeaFlowDynamicVCAggTraversal extends
+    IncVertexCentricAggTraversal<Object, Row, Row, MessageBox, ITreePath, ITraversalAgg,
+        ITraversalAgg, ITraversalAgg, ITraversalAgg, ITraversalAgg> {
+
+    private final ExecuteDagGroup executeDagGroup;
+
+    private final boolean isTraversalAllWithRequest;
+
+    private final int parallelism;
+
+    public GeaFlowDynamicVCAggTraversal(ExecuteDagGroup executeDagGroup,
+                                        int maxTraversal,
+                                        boolean isTraversalAllWithRequest,
+                                        int parallelism) {
+        super(maxTraversal);
+        this.executeDagGroup = executeDagGroup;
+        this.isTraversalAllWithRequest = isTraversalAllWithRequest;
+        assert parallelism > 0;
+        this.parallelism = parallelism;
+    }
+
+    @Override
+    public VertexCentricCombineFunction<MessageBox> getCombineFunction() {
+        return new MessageBoxCombineFunction();
+    }
+
+    @Override
+    public IncVertexCentricAggTraversalFunction<Object, Row, Row, MessageBox, ITreePath,
+        ITraversalAgg, ITraversalAgg> getIncTraversalFunction() {
+        return new GeaFlowDynamicVCAggTraversalFunction(executeDagGroup, isTraversalAllWithRequest);
+    }
+
+    @Override
+    public VertexCentricAggregateFunction<ITraversalAgg, ITraversalAgg, ITraversalAgg,
+        ITraversalAgg, ITraversalAgg> getAggregateFunction() {
+        return (VertexCentricAggregateFunction) new GeaFlowKVTraversalAggregateFunction(parallelism);
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicVCAggTraversalFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowDynamicVCAggTraversalFunction.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.api.function.iterator.RichIteratorFunction;
+import com.antgroup.geaflow.api.graph.function.vc.IncVertexCentricAggTraversalFunction;
+import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.ExecuteDagGroup;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
+import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
+import com.antgroup.geaflow.model.graph.edge.IEdge;
+import com.antgroup.geaflow.model.graph.vertex.IVertex;
+import com.antgroup.geaflow.model.traversal.ITraversalRequest;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class GeaFlowDynamicVCAggTraversalFunction implements
+    IncVertexCentricAggTraversalFunction<Object, Row, Row, MessageBox, ITreePath, ITraversalAgg,
+        ITraversalAgg>, RichIteratorFunction {
+
+    private static final long VERSION = 0L;
+
+    private GeaFlowDynamicTraversalRuntimeContext traversalRuntimeContext;
+
+    private final GeaFlowCommonTraversalFunction commonFunction;
+
+    private MutableGraph<Object, Row, Row> mutableGraph;
+
+    public GeaFlowDynamicVCAggTraversalFunction(ExecuteDagGroup executeDagGroup, boolean isTraversalAllWithRequest) {
+        this.commonFunction = new GeaFlowCommonTraversalFunction(executeDagGroup, isTraversalAllWithRequest);
+    }
+
+    @Override
+    public void open(
+        IncVertexCentricTraversalFuncContext<Object, Row, Row, MessageBox, ITreePath> vertexCentricFuncContext) {
+        traversalRuntimeContext = new GeaFlowDynamicTraversalRuntimeContext(
+            vertexCentricFuncContext);
+        this.mutableGraph = vertexCentricFuncContext.getMutableGraph();
+        this.commonFunction.open(traversalRuntimeContext);
+    }
+
+    @Override
+    public void evolve(Object vertexId, TemporaryGraph<Object, Row, Row> temporaryGraph) {
+        IVertex<Object, Row> vertex = temporaryGraph.getVertex();
+        if (vertex != null) {
+            mutableGraph.addVertex(VERSION, vertex);
+        }
+        List<IEdge<Object, Row>> edges = temporaryGraph.getEdges();
+        if (edges != null) {
+            for (IEdge<Object, Row> edge : edges) {
+                mutableGraph.addEdge(VERSION, edge);
+            }
+        }
+    }
+
+    @Override
+    public void initIteration(long windowId) {
+
+    }
+
+    @Override
+    public void init(ITraversalRequest<Object> traversalRequest) {
+        commonFunction.init(traversalRequest);
+    }
+
+    @Override
+    public void compute(Object vertexId, Iterator<MessageBox> messageIterator) {
+        commonFunction.compute(vertexId, messageIterator);
+    }
+
+    @Override
+    public void finishIteration(long windowId) {
+        commonFunction.finish(windowId);
+    }
+
+    @Override
+    public void finish(Object vertexId, MutableGraph<Object, Row, Row> mutableGraph) {
+
+    }
+
+    @Override
+    public void initContext(VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext) {
+        this.traversalRuntimeContext.setAggContext(Objects.requireNonNull(aggContext));
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowKVAlgorithmAggregateFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowKVAlgorithmAggregateFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.dsl.runtime.traversal.message.KVTraversalAgg;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+public class GeaFlowKVAlgorithmAggregateFunction extends GeaFlowKVTraversalAggregateFunction {
+
+    private static final String ALGORITHM_ITERATION_PREFIX = "AlgorithmIteration-";
+
+    public GeaFlowKVAlgorithmAggregateFunction(int parallelism) {
+        super(parallelism);
+    }
+
+    public static KVTraversalAgg getAlgorithmAgg(long iteration) {
+        return new KVTraversalAgg(ALGORITHM_ITERATION_PREFIX + iteration, 1);
+    }
+
+    @Override
+    public IPartialGraphAggFunction<KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>> getPartialAggregation() {
+        return new IPartialGraphAggFunction<KVTraversalAgg<String, Integer>,
+            KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>>() {
+
+            private IPartialAggContext<KVTraversalAgg<String, Integer>> partialAggContext;
+
+            @Override
+            public KVTraversalAgg<String, Integer> create(
+                IPartialAggContext<KVTraversalAgg<String, Integer>> partialAggContext) {
+                this.partialAggContext = Objects.requireNonNull(partialAggContext);
+                return KVTraversalAgg.empty();
+            }
+
+
+            @Override
+            public KVTraversalAgg<String, Integer> aggregate(KVTraversalAgg<String, Integer> iterm,
+                                                             KVTraversalAgg<String, Integer> result) {
+                if (iterm == null) {
+                    return result;
+                } else if (result == null) {
+                    return iterm;
+                }
+                for (Entry<String, Integer> entryObj : iterm.getMap().entrySet()) {
+                    String key = entryObj.getKey();
+                    if (result.getMap().containsKey(key)) {
+                        result.getMap().put(key, result.getMap().get(key) + entryObj.getValue());
+                    } else {
+                        result.getMap().put(key, entryObj.getValue());
+                    }
+                }
+                return result;
+            }
+
+            @Override
+            public void finish(KVTraversalAgg<String, Integer> result) {
+                assert partialAggContext != null;
+                if (result != null) {
+                    KVTraversalAgg<String, Integer> tmpResult = result.copy();
+                    partialAggContext.collect(tmpResult);
+                }
+            }
+        };
+    }
+
+    @Override
+    public IGraphAggregateFunction<KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>> getGlobalAggregation() {
+        return new IGraphAggregateFunction<KVTraversalAgg<String, Integer>,
+            KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>>() {
+
+            private IGlobalGraphAggContext<KVTraversalAgg<String, Integer>> globalGraphAggContext;
+
+            @Override
+            public KVTraversalAgg<String, Integer> create(
+                IGlobalGraphAggContext<KVTraversalAgg<String, Integer>> globalGraphAggContext) {
+                this.globalGraphAggContext = Objects.requireNonNull(globalGraphAggContext);
+                return KVTraversalAgg.empty();
+            }
+
+            @Override
+            public KVTraversalAgg<String, Integer> aggregate(KVTraversalAgg<String, Integer> iterm,
+                                                             KVTraversalAgg<String, Integer> result) {
+                if (iterm == null) {
+                    return result;
+                } else if (result == null) {
+                    return iterm;
+                }
+                for (Entry<String, Integer> entryObj : iterm.getMap().entrySet()) {
+                    String key = entryObj.getKey();
+                    if (result.getMap().containsKey(key)) {
+                        result.getMap().put(key, result.getMap().get(key) + entryObj.getValue());
+                    } else {
+                        result.getMap().put(key, entryObj.getValue());
+                    }
+                }
+                return result;
+            }
+
+            @Override
+            public void finish(KVTraversalAgg<String, Integer> value) {
+                assert globalGraphAggContext != null;
+                long currentIteration = globalGraphAggContext.getIteration();
+                String key = ALGORITHM_ITERATION_PREFIX + currentIteration;
+                if (value == null || value.get(key) == null || value.get(key) == 0) {
+                    globalGraphAggContext.terminate();
+                }
+            }
+        };
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowKVTraversalAggregateFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowKVTraversalAggregateFunction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricAggregateFunction;
+import com.antgroup.geaflow.dsl.runtime.traversal.collector.StepEndCollector;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.KVTraversalAgg;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+public class GeaFlowKVTraversalAggregateFunction implements VertexCentricAggregateFunction
+    <KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>> {
+
+    private final int parallelism;
+
+    public GeaFlowKVTraversalAggregateFunction(int parallelism) {
+        assert parallelism > 0 : "GeaFlowKVTraversalAggregateFunction parallelism <= 0";
+        this.parallelism = parallelism;
+    }
+
+    @Override
+    public IPartialGraphAggFunction<KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>> getPartialAggregation() {
+        return new IPartialGraphAggFunction<KVTraversalAgg<String, Integer>,
+            KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>>() {
+
+            private IPartialAggContext<KVTraversalAgg<String, Integer>> partialAggContext;
+
+            @Override
+            public KVTraversalAgg<String, Integer> create(
+                IPartialAggContext<KVTraversalAgg<String, Integer>> partialAggContext) {
+                this.partialAggContext = Objects.requireNonNull(partialAggContext);
+                return KVTraversalAgg.empty();
+            }
+
+
+            @Override
+            public KVTraversalAgg<String, Integer> aggregate(KVTraversalAgg<String, Integer> iterm,
+                                                             KVTraversalAgg<String, Integer> result) {
+                if (iterm == null) {
+                    return result;
+                } else if (result == null) {
+                    return iterm;
+                }
+                for (Entry<String, Integer> entryObj : iterm.getMap().entrySet()) {
+                    String key = entryObj.getKey();
+                    if (result.getMap().containsKey(key)) {
+                        result.getMap().put(key, result.getMap().get(key) + entryObj.getValue());
+                    } else {
+                        result.getMap().put(key, entryObj.getValue());
+                    }
+                }
+                return result;
+            }
+
+            @Override
+            public void finish(KVTraversalAgg<String, Integer> result) {
+                assert partialAggContext != null;
+                if (result != null) {
+                    KVTraversalAgg<String, Integer> tmpResult = result.copy();
+                    partialAggContext.collect(tmpResult);
+                }
+            }
+        };
+    }
+
+    @Override
+    public IGraphAggregateFunction<KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>,
+        KVTraversalAgg<String, Integer>> getGlobalAggregation() {
+        return new IGraphAggregateFunction<KVTraversalAgg<String, Integer>,
+            KVTraversalAgg<String, Integer>, KVTraversalAgg<String, Integer>>() {
+
+            private IGlobalGraphAggContext<KVTraversalAgg<String, Integer>> globalGraphAggContext;
+
+            @Override
+            public KVTraversalAgg<String, Integer> create(
+                IGlobalGraphAggContext<KVTraversalAgg<String, Integer>> globalGraphAggContext) {
+                this.globalGraphAggContext = Objects.requireNonNull(globalGraphAggContext);
+                return KVTraversalAgg.empty();
+            }
+
+            @Override
+            public KVTraversalAgg<String, Integer> aggregate(KVTraversalAgg<String, Integer> iterm,
+                                                             KVTraversalAgg<String, Integer> result) {
+                if (iterm == null) {
+                    return result;
+                } else if (result == null) {
+                    return iterm;
+                }
+                for (Entry<String, Integer> entryObj : iterm.getMap().entrySet()) {
+                    String key = entryObj.getKey();
+                    if (result.getMap().containsKey(key)) {
+                        result.getMap().put(key, result.getMap().get(key) + entryObj.getValue());
+                    } else {
+                        result.getMap().put(key, entryObj.getValue());
+                    }
+                }
+                return result;
+            }
+
+            @Override
+            public void finish(KVTraversalAgg<String, Integer> value) {
+                assert globalGraphAggContext != null;
+                if (value != null && value.getMap().containsKey(StepEndCollector.TRAVERSAL_FINISH)
+                    && value.get(StepEndCollector.TRAVERSAL_FINISH) >= parallelism) {
+                    globalGraphAggContext.terminate();
+                }
+            }
+        };
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticTraversalRuntimeContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticTraversalRuntimeContext.java
@@ -18,6 +18,7 @@ import com.antgroup.geaflow.api.context.RuntimeContext;
 import com.antgroup.geaflow.api.graph.function.vc.VertexCentricTraversalFunction.VertexCentricTraversalFuncContext;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.KVTraversalAgg;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
 import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
 import com.antgroup.geaflow.model.graph.message.DefaultGraphMessage;
@@ -64,7 +65,11 @@ public class GeaFlowStaticTraversalRuntimeContext extends AbstractTraversalRunti
 
     @Override
     public void sendCoordinator(String name, Object value) {
-        LOGGER.info("task: {} send to coordinator {}:{} ", getTaskIndex(), name, value);
+        LOGGER.info("task: {} send to coordinator {}:{} isAggTraversal:{}", getTaskIndex(), name,
+            value, aggContext != null);
+        if (aggContext != null) {
+            aggContext.aggregate(new KVTraversalAgg(name, value));
+        }
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticVCAggTraversal.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticVCAggTraversal.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricAggTraversalFunction;
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricAggregateFunction;
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricCombineFunction;
+import com.antgroup.geaflow.api.graph.traversal.VertexCentricAggTraversal;
+import com.antgroup.geaflow.common.encoder.IEncoder;
+import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.ExecuteDagGroup;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
+import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
+import java.util.Objects;
+
+public class GeaFlowStaticVCAggTraversal extends VertexCentricAggTraversal<Object, Row, Row,
+    MessageBox, ITreePath,
+    ITraversalAgg, ITraversalAgg, ITraversalAgg, ITraversalAgg, ITraversalAgg> {
+    private final ExecuteDagGroup executeDagGroup;
+
+    private final boolean isTraversalAllWithRequest;
+
+    private final int parallelism;
+
+    public GeaFlowStaticVCAggTraversal(ExecuteDagGroup executeDagGroup,
+                                       int maxTraversal,
+                                       boolean isTraversalAllWithRequest,
+                                       int parallelism) {
+        super(maxTraversal);
+        this.executeDagGroup = Objects.requireNonNull(executeDagGroup);
+        this.isTraversalAllWithRequest = isTraversalAllWithRequest;
+        assert parallelism > 0;
+        this.parallelism = parallelism;
+    }
+
+    @Override
+    public VertexCentricCombineFunction<MessageBox> getCombineFunction() {
+        return new MessageBoxCombineFunction();
+    }
+
+    @Override
+    public IEncoder<MessageBox> getMessageEncoder() {
+        return null;
+    }
+
+    @Override
+    public VertexCentricAggTraversalFunction<Object, Row, Row, MessageBox, ITreePath, ITraversalAgg,
+        ITraversalAgg> getTraversalFunction() {
+        return new GeaFlowStaticVCAggTraversalFunction(executeDagGroup, isTraversalAllWithRequest);
+    }
+
+    @Override
+    public VertexCentricAggregateFunction<ITraversalAgg, ITraversalAgg, ITraversalAgg, ITraversalAgg, ITraversalAgg> getAggregateFunction() {
+        return (VertexCentricAggregateFunction) new GeaFlowKVTraversalAggregateFunction(parallelism);
+    }
+
+    private static class MessageBoxCombineFunction implements VertexCentricCombineFunction<MessageBox> {
+
+        @Override
+        public MessageBox combine(MessageBox oldMessage, MessageBox newMessage) {
+            return newMessage.combine(oldMessage);
+        }
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticVCAggTraversalFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowStaticVCAggTraversalFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.engine;
+
+import com.antgroup.geaflow.api.function.iterator.RichIteratorFunction;
+import com.antgroup.geaflow.api.graph.function.vc.VertexCentricAggTraversalFunction;
+import com.antgroup.geaflow.dsl.common.data.Row;
+import com.antgroup.geaflow.dsl.runtime.traversal.ExecuteDagGroup;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
+import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
+import com.antgroup.geaflow.model.traversal.ITraversalRequest;
+import java.util.Iterator;
+import java.util.Objects;
+
+public class GeaFlowStaticVCAggTraversalFunction implements
+    VertexCentricAggTraversalFunction<Object, Row, Row, MessageBox, ITreePath, ITraversalAgg,
+        ITraversalAgg>, RichIteratorFunction {
+
+    private final GeaFlowCommonTraversalFunction commonFunction;
+    private GeaFlowStaticTraversalRuntimeContext traversalRuntimeContext;
+
+    public GeaFlowStaticVCAggTraversalFunction(ExecuteDagGroup executeDagGroup, boolean isTraversalAllWithRequest) {
+        this.commonFunction = new GeaFlowCommonTraversalFunction(executeDagGroup, isTraversalAllWithRequest);
+    }
+
+    @Override
+    public void open(
+        VertexCentricTraversalFuncContext<Object, Row, Row, MessageBox, ITreePath> vertexCentricFuncContext) {
+        commonFunction.open(this.traversalRuntimeContext =
+            new GeaFlowStaticTraversalRuntimeContext(vertexCentricFuncContext));
+    }
+
+    @Override
+    public void initIteration(long windowId) {
+
+    }
+
+    @Override
+    public void init(ITraversalRequest<Object> traversalRequest) {
+        commonFunction.init(traversalRequest);
+    }
+
+    @Override
+    public void compute(Object vertexId, Iterator<MessageBox> messageIterator) {
+        commonFunction.compute(vertexId, messageIterator);
+    }
+
+    @Override
+    public void finishIteration(long windowId) {
+        commonFunction.finish(windowId);
+    }
+
+    @Override
+    public void finish() {
+
+    }
+
+    @Override
+    public void close() {
+        commonFunction.close();
+    }
+
+    @Override
+    public void initContext(VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext) {
+        this.traversalRuntimeContext.setAggContext(Objects.requireNonNull(aggContext));
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/plan/PhysicGraphScanRelNode.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/plan/PhysicGraphScanRelNode.java
@@ -33,8 +33,13 @@ public class PhysicGraphScanRelNode extends GraphScan implements PhysicRelNode<R
     @Override
     public RuntimeGraph translate(QueryContext context) {
         GeaFlowGraph graph = table.unwrap(GeaFlowGraph.class);
-        context.addReferSourceGraph(graph);
-        return context.getEngineContext().createRuntimeGraph(context, graph);
+        RuntimeGraph runtimeGraph = context.getRuntimeGraph(graph.getName());
+        if (runtimeGraph == null) {
+            context.addReferSourceGraph(graph);
+            runtimeGraph = context.getEngineContext().createRuntimeGraph(context, graph);
+            context.putRuntimeGraph(graph.getName(), runtimeGraph);
+        }
+        return runtimeGraph;
     }
 
     @Override

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/DagTopologyGroup.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/DagTopologyGroup.java
@@ -16,6 +16,7 @@ package com.antgroup.geaflow.dsl.runtime.traversal;
 
 import com.antgroup.geaflow.dsl.common.data.StepRecord;
 import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
+import com.antgroup.geaflow.dsl.runtime.traversal.operator.StepLoopUntilOperator;
 import com.antgroup.geaflow.dsl.runtime.traversal.operator.StepOperator;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
@@ -126,5 +127,56 @@ public class DagTopologyGroup {
 
     public Collection<StepOperator<StepRecord, StepRecord>> getAllOperators() {
         return globalOpId2Operators.values();
+    }
+
+    public int getIterationCount(int currentDepth, StepOperator stepOperator) {
+        List<String> subQueryNames = stepOperator.getSubQueryNames();
+        int maxSubDagIteration = 0;
+        for (String subQueryName : subQueryNames) {
+            DagTopology subDag = this.subDags.get(subQueryName);
+            assert subDag != null;
+            int subDagIterationCount =
+                addIteration(getIterationCount(1, subDag.getEntryOperator()), 1);
+            if (subDagIterationCount > maxSubDagIteration) {
+                maxSubDagIteration = subDagIterationCount;
+            }
+        }
+        currentDepth += addIteration(currentDepth, maxSubDagIteration);
+
+        if (stepOperator instanceof StepLoopUntilOperator) {
+            StepLoopUntilOperator loopUntilOperator = (StepLoopUntilOperator)stepOperator;
+            currentDepth = addIteration(currentDepth, loopUntilOperator.getMaxLoopCount());
+        }
+        int depth = currentDepth;
+        for (Object op : stepOperator.getNextOperators()) {
+            StepOperator next = (StepOperator) op;
+            int branchDepth = getIterationCount(currentDepth, next);
+            if (!isChained(stepOperator.getId(), next.getId())) {
+                branchDepth = addIteration(branchDepth, 1);
+            }
+            if (branchDepth > depth) {
+                depth = branchDepth;
+            }
+        }
+        return depth;
+    }
+
+    private static int addIteration(int iteration, int delta) {
+        if (iteration == Integer.MAX_VALUE || iteration < 0 || delta == 0) {
+            return iteration;
+        }
+        if (delta > 0) {
+            if (Integer.MAX_VALUE - iteration >= delta) {
+                return iteration + delta;
+            } else {
+                return Integer.MAX_VALUE;
+            }
+        } else {
+            if (iteration + delta >= 0) {
+                return iteration + delta;
+            } else {
+                return iteration;
+            }
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/ExecuteDagGroupImpl.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/ExecuteDagGroupImpl.java
@@ -127,4 +127,9 @@ public class ExecuteDagGroupImpl implements ExecuteDagGroup {
     public DagTopology getMainDag() {
         return dagGroup.getMainDag();
     }
+
+    @Override
+    public int getMaxIterationCount() {
+        return dagGroup.getIterationCount(1, dagGroup.getMainDag().getEntryOperator());
+    }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/TraversalRuntimeContext.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/TraversalRuntimeContext.java
@@ -15,6 +15,7 @@
 package com.antgroup.geaflow.dsl.runtime.traversal;
 
 import com.antgroup.geaflow.api.context.RuntimeContext;
+import com.antgroup.geaflow.api.graph.function.aggregate.VertexCentricAggContextFunction.VertexCentricAggContext;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.common.type.IType;
 import com.antgroup.geaflow.dsl.common.data.Row;
@@ -25,6 +26,7 @@ import com.antgroup.geaflow.dsl.runtime.traversal.data.CallRequestId;
 import com.antgroup.geaflow.dsl.runtime.traversal.data.EdgeGroup;
 import com.antgroup.geaflow.dsl.runtime.traversal.data.ParameterRequest;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.IMessage;
+import com.antgroup.geaflow.dsl.runtime.traversal.message.ITraversalAgg;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
 import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageType;
 import com.antgroup.geaflow.dsl.runtime.traversal.path.ITreePath;
@@ -80,6 +82,10 @@ public interface TraversalRuntimeContext {
     void takePath(ITreePath treePath);
 
     void sendCoordinator(String name, Object value);
+
+    VertexCentricAggContext<ITraversalAgg, ITraversalAgg> getAggContext();
+
+    void setAggContext(VertexCentricAggContext<ITraversalAgg, ITraversalAgg> aggContext);
 
     RuntimeContext getRuntimeContext();
 

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ITraversalAgg.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/ITraversalAgg.java
@@ -12,25 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package com.antgroup.geaflow.dsl.runtime.traversal;
+package com.antgroup.geaflow.dsl.runtime.traversal.message;
 
-import com.antgroup.geaflow.dsl.runtime.traversal.message.MessageBox;
+public interface ITraversalAgg {
 
-public interface ExecuteDagGroup {
-
-    void open(TraversalRuntimeContext context);
-
-    void execute(Object vertexId, long... receiverOpIds);
-
-    void finishIteration(long iterationId);
-
-    void processBroadcast(MessageBox messageBox);
-
-    void close();
-
-    long getEntryOpId();
-
-    DagTopology getMainDag();
-
-    int getMaxIterationCount();
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/KVTraversalAgg.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/message/KVTraversalAgg.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.traversal.message;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KVTraversalAgg<K, V> implements ITraversalAgg {
+
+    private final Map<K, V> map;
+
+    public KVTraversalAgg() {
+        this.map = new HashMap<>();
+    }
+
+    public KVTraversalAgg(Map<K, V> map) {
+        this.map = new HashMap<>(map);
+    }
+
+    public KVTraversalAgg(K key, V value) {
+        this.map = Collections.singletonMap(key, value);
+    }
+
+    public Map<K, V> getMap() {
+        return map;
+    }
+
+    public V get(K key) {
+        return this.map.get(key);
+    }
+
+    public void clear() {
+        this.map.clear();
+    }
+
+    public KVTraversalAgg<K, V> copy() {
+        return new KVTraversalAgg<>(map);
+    }
+
+    public static <K, V> KVTraversalAgg<K, V> empty() {
+        return new KVTraversalAgg();
+    }
+
+    @Override
+    public String toString() {
+        return "KVTraversalAgg{" + "map=" + map + '}';
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/AbstractStepOperator.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/AbstractStepOperator.java
@@ -429,11 +429,17 @@ public abstract class AbstractStepOperator<FUNC extends StepFunction, IN extends
     public void close() {
     }
 
+    @Override
     public void addNextOperator(StepOperator nextOperator) {
         if (nextOperators.contains(nextOperator)) {
             return;
         }
         this.nextOperators.add(nextOperator);
+    }
+
+    @Override
+    public List<StepOperator<OUT, ?>> getNextOperators() {
+        return this.nextOperators;
     }
 
     @Override
@@ -533,12 +539,17 @@ public abstract class AbstractStepOperator<FUNC extends StepFunction, IN extends
     }
 
     @Override
+    public List<String> getSubQueryNames() {
+        return function.getCallQueryProxies().stream()
+            .flatMap(proxy -> proxy.getSubQueryNames().stream())
+            .collect(Collectors.toList());
+    }
+
+    @Override
     public String toString() {
         StringBuilder str = new StringBuilder();
         str.append(getName());
-        List<String> subQueryNames = function.getCallQueryProxies().stream()
-            .flatMap(proxy -> proxy.getSubQueryNames().stream())
-            .collect(Collectors.toList());
+        List<String> subQueryNames = getSubQueryNames();
         if (subQueryNames.size() > 0) {
             str.append("[").append(StringUtils.join(subQueryNames, ",")).append("]");
         }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/StepLoopUntilOperator.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/StepLoopUntilOperator.java
@@ -132,4 +132,12 @@ public class StepLoopUntilOperator extends AbstractStepOperator<StepBoolFunction
         this.numProcessRecords = 0L;
         this.loopCounter++;
     }
+
+    public int getMinLoopCount() {
+        return this.minLoopCount;
+    }
+
+    public int getMaxLoopCount() {
+        return this.maxLoopCount;
+    }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/StepOperator.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/traversal/operator/StepOperator.java
@@ -54,6 +54,8 @@ public interface StepOperator<IN extends StepRecord, OUT extends StepRecord> ext
 
     void addNextOperator(StepOperator<OUT, ? extends StepRecord> nextOperator);
 
+    List<StepOperator<OUT, ?>> getNextOperators();
+
     StepOperator<IN, OUT> withName(String name);
 
     /**
@@ -95,6 +97,8 @@ public interface StepOperator<IN extends StepRecord, OUT extends StepRecord> ext
     GraphSchema getGraphSchema();
 
     GraphSchema getModifyGraphSchema();
+
+    List<String> getSubQueryNames();
 
     StepOperator<IN, OUT> copy();
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/QueryUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/QueryUtil.java
@@ -64,8 +64,7 @@ public class QueryUtil {
                     SqlIdentifier graphName = gqlContext.completeCatalogObjName(createGraph.getName());
                     if (createGraph.getVertices().getList().stream().anyMatch(node -> node instanceof SqlVertexUsing)
                         || createGraph.getEdges().getList().stream().anyMatch(node -> node instanceof SqlEdgeUsing)) {
-                        GeaFlowGraph graph = gqlContext.convertToGraph(createGraph,
-                            createTablesInScript, config);
+                        GeaFlowGraph graph = gqlContext.convertToGraph(createGraph, createTablesInScript);
                         Configuration globalConfig = graph.getConfigWithGlobal(config);
                         if (!QueryUtil.isGraphExists(graph, globalConfig)) {
                             preCompileResult.addGraph(SchemaUtil.buildGraphViewDesc(graph, globalConfig));
@@ -80,7 +79,7 @@ public class QueryUtil {
                     SqlIdentifier insertGraphName = GQLNodeUtil.getGraphTableName(insertName);
                     if (createGraphs.containsKey(insertGraphName.toString())) {
                         SqlCreateGraph createGraph = createGraphs.get(insertGraphName.toString());
-                        GeaFlowGraph graph = gqlContext.convertToGraph(createGraph, config);
+                        GeaFlowGraph graph = gqlContext.convertToGraph(createGraph);
                         preCompileResult.addGraph(SchemaUtil.buildGraphViewDesc(graph, config));
                     } else {
                         Table graph = gqlContext.getCatalog().getGraph(gqlContext.getCurrentInstance(),

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/KafkaFoTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/KafkaFoTest.java
@@ -15,12 +15,12 @@
 package com.antgroup.geaflow.dsl.runtime.query;
 
 import com.antgroup.geaflow.common.config.keys.DSLConfigKeys;
+import com.antgroup.geaflow.dsl.connector.kafka.KafkaConfigKeys;
 import com.antgroup.geaflow.dsl.runtime.testenv.KafkaTestEnv;
 import com.antgroup.geaflow.dsl.runtime.testenv.SourceFunctionNoPartitionCheck;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -67,7 +67,7 @@ public class KafkaFoTest {
             .withTestTimeWaitSeconds(60);
         try {
             tester.execute();
-        } catch (TimeoutException e) {
+        } catch (Exception e) {
             LOGGER.info("Kafka unbounded stream finish with timeout.");
         }
         tester.checkSinkResult();


### PR DESCRIPTION
### What changes were proposed in this pull request?
提前结束ISSUE-#167已经合并，PR见https://github.com/TuGraph-family/tugraph-analytics/pull/168
The early termination ISSUE-https://github.com/TuGraph-family/tugraph-analytics/issues/167 has been merged, and the corresponding PR can be found at https://github.com/TuGraph-family/tugraph-analytics/pull/168.

现在需要在DSL Traversal and Algorithm 两种计算中支持提前结束，实现相应的AggregateFunction.
Now, it is required to support early termination in both DSL Traversal and Algorithm calculations, and implement the corresponding AggregateFunction.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
