### PR TITLE
[ISSUE-179] Support converting traversal all to traversal by stream

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/config/keys/DSLConfigKeys.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/config/keys/DSLConfigKeys.java
@@ -80,4 +80,9 @@ public class DSLConfigKeys implements Serializable {
         .key("geaflow.dsl.ignore.exception")
         .defaultValue(false)
         .description("If set true, dsl will skip the exception for dirty data.");
+
+    public static final ConfigKey GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE = ConfigKeys
+        .key("geaflow.dsl.traversal.all.split.enable")
+        .defaultValue(false)
+        .description("Whether enable the split of the ids for traversal all. ");
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryEngine.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/QueryEngine.java
@@ -14,6 +14,8 @@
 
 package com.antgroup.geaflow.dsl.runtime;
 
+import com.antgroup.geaflow.api.function.io.SourceFunction;
+import com.antgroup.geaflow.api.pdata.stream.window.PWindowSource;
 import com.antgroup.geaflow.dsl.common.data.Row;
 import com.antgroup.geaflow.dsl.runtime.expression.Expression;
 import com.antgroup.geaflow.dsl.schema.GeaFlowGraph;
@@ -34,6 +36,8 @@ public interface QueryEngine {
     RuntimeTable createRuntimeTable(QueryContext context, GeaFlowTable table, Expression pushFilter);
 
     RuntimeTable createRuntimeTable(QueryContext context, Collection<Row> rows);
+
+    <T> PWindowSource<T> createRuntimeTable(QueryContext context, SourceFunction<T> sourceFunction);
 
     RuntimeGraph createRuntimeGraph(QueryContext context, GeaFlowGraph graph);
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowQueryEngine.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/engine/GeaFlowQueryEngine.java
@@ -15,6 +15,7 @@
 package com.antgroup.geaflow.dsl.runtime.engine;
 
 import com.antgroup.geaflow.api.function.internal.CollectionSource;
+import com.antgroup.geaflow.api.function.io.SourceFunction;
 import com.antgroup.geaflow.api.pdata.stream.window.PWindowSource;
 import com.antgroup.geaflow.api.window.IWindow;
 import com.antgroup.geaflow.common.config.Configuration;
@@ -152,6 +153,13 @@ public class GeaFlowQueryEngine implements QueryEngine {
             .withName(PhysicRelNodeName.VALUE_SCAN.getName(context.getOpNameCount()))
             .withParallelism(1);
         return new GeaFlowRuntimeTable(context, pipelineContext, source);
+    }
+
+    @Override
+    public <T> PWindowSource<T> createRuntimeTable(QueryContext context, SourceFunction<T> sourceFunction) {
+        IWindow<T> window = Windows.createWindow(pipelineContext.getConfig());
+        return pipelineContext.buildSource(sourceFunction, window)
+            .withConfig(context.getSetOptions());
     }
 
     @SuppressWarnings("unchecked")

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/AbstractVertexScanSourceFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/AbstractVertexScanSourceFunction.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.function.graph.source;
+
+import com.antgroup.geaflow.api.context.RuntimeContext;
+import com.antgroup.geaflow.api.function.RichFunction;
+import com.antgroup.geaflow.api.function.io.SourceFunction;
+import com.antgroup.geaflow.api.window.IWindow;
+import com.antgroup.geaflow.common.config.Configuration;
+import com.antgroup.geaflow.common.config.keys.DSLConfigKeys;
+import com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys;
+import com.antgroup.geaflow.common.exception.GeaflowRuntimeException;
+import com.antgroup.geaflow.dsl.runtime.traversal.data.IdOnlyRequest;
+import com.antgroup.geaflow.state.GraphState;
+import com.antgroup.geaflow.state.StateFactory;
+import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
+import com.antgroup.geaflow.utils.keygroup.IKeyGroupAssigner;
+import com.antgroup.geaflow.utils.keygroup.KeyGroup;
+import com.antgroup.geaflow.utils.keygroup.KeyGroupAssignerFactory;
+import com.antgroup.geaflow.utils.keygroup.KeyGroupAssignment;
+import com.antgroup.geaflow.view.IViewDesc.BackendType;
+import com.antgroup.geaflow.view.graph.GraphViewDesc;
+import com.antgroup.geaflow.view.meta.ViewMetaBookKeeper;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractVertexScanSourceFunction<K> extends RichFunction implements
+    SourceFunction<IdOnlyRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractVertexScanSourceFunction.class);
+
+    protected transient RuntimeContext runtimeContext;
+
+    protected GraphViewDesc graphViewDesc;
+
+    protected transient GraphState<K, ?, ?> graphState;
+
+    private Iterator<K> idIterator;
+
+    private long windSize;
+
+    public AbstractVertexScanSourceFunction(GraphViewDesc graphViewDesc) {
+        this.graphViewDesc = Objects.requireNonNull(graphViewDesc);
+    }
+
+    @Override
+    public void open(RuntimeContext runtimeContext) {
+        this.runtimeContext = runtimeContext;
+        this.windSize = this.runtimeContext.getConfiguration().getLong(DSLConfigKeys.GEAFLOW_DSL_WINDOW_SIZE);
+        Configuration rewriteConfiguration = runtimeContext.getConfiguration();
+        String jobName = rewriteConfiguration.getString(ExecutionConfigKeys.JOB_APP_NAME);
+        rewriteConfiguration.put(ExecutionConfigKeys.JOB_APP_NAME.getKey(),
+            "VertexScanSourceFunction_" + jobName);
+        GraphStateDescriptor<K, ?, ?> desc = buildGraphStateDesc();
+        desc.withMetricGroup(runtimeContext.getMetric());
+        this.graphState = StateFactory.buildGraphState(desc, runtimeContext.getConfiguration());
+        recover();
+        this.idIterator = buildIdIterator();
+    }
+
+    protected abstract Iterator<K> buildIdIterator();
+
+    protected void recover() {
+        LOGGER.info("Task: {} will do recover, windowId: {}",
+            this.runtimeContext.getTaskArgs().getTaskId(), this.runtimeContext.getWindowId());
+        long lastCheckPointId = getLatestViewVersion();
+        if (lastCheckPointId >= 0) {
+            LOGGER.info("Task: {} do recover to state VersionId: {}", this.runtimeContext.getTaskArgs().getTaskId(),
+                lastCheckPointId);
+            graphState.manage().operate().setCheckpointId(lastCheckPointId);
+            graphState.manage().operate().recover();
+        }
+    }
+
+    @Override
+    public void init(int parallel, int index) {
+
+    }
+
+    protected GraphStateDescriptor<K, ?, ?> buildGraphStateDesc() {
+        int taskIndex = runtimeContext.getTaskArgs().getTaskIndex();
+        int taskPara = runtimeContext.getTaskArgs().getParallelism();
+        BackendType backendType = graphViewDesc.getBackend();
+        GraphStateDescriptor<K, ?, ?> desc = GraphStateDescriptor.build(graphViewDesc.getName()
+            , backendType.name());
+
+        int maxPara = graphViewDesc.getShardNum();
+        Preconditions.checkArgument(taskPara <= maxPara,
+            String.format("task parallelism '%s' must be <= shard num(max parallelism) '%s'",
+                taskPara, maxPara));
+
+        KeyGroup keyGroup = KeyGroupAssignment.computeKeyGroupRangeForOperatorIndex(maxPara, taskPara, taskIndex);
+        IKeyGroupAssigner keyGroupAssigner =
+            KeyGroupAssignerFactory.createKeyGroupAssigner(keyGroup, taskIndex, maxPara);
+        desc.withKeyGroup(keyGroup);
+        desc.withKeyGroupAssigner(keyGroupAssigner);
+
+        long taskId = runtimeContext.getTaskArgs().getTaskId();
+        int containerNum = runtimeContext.getConfiguration().getInteger(ExecutionConfigKeys.CONTAINER_NUM);
+        LOGGER.info("Task:{} taskId:{} taskIndex:{} keyGroup:{} containerNum:{} real taskIndex:{}",
+            this.runtimeContext.getTaskArgs().getTaskName(),
+            taskId,
+            taskIndex,
+            desc.getKeyGroup(), containerNum, runtimeContext.getTaskArgs().getTaskIndex());
+        return desc;
+    }
+
+    protected long getLatestViewVersion() {
+        long lastCheckPointId;
+        try {
+            ViewMetaBookKeeper keeper = new ViewMetaBookKeeper(graphViewDesc.getName(),
+                this.runtimeContext.getConfiguration());
+            lastCheckPointId = keeper.getLatestViewVersion(graphViewDesc.getName());
+            LOGGER.info("Task: {} will do recover or load, ViewMetaBookKeeper version: {}",
+                runtimeContext.getTaskArgs().getTaskId(), lastCheckPointId);
+        } catch (IOException e) {
+            throw new GeaflowRuntimeException(e);
+        }
+        return lastCheckPointId;
+    }
+
+    @Override
+    public boolean fetch(IWindow<IdOnlyRequest> window, SourceContext<IdOnlyRequest> ctx) throws Exception {
+        int count = 0;
+        while (idIterator.hasNext()) {
+            K id = idIterator.next();
+            IdOnlyRequest idOnlyRequest = new IdOnlyRequest(id);
+            ctx.collect(idOnlyRequest);
+            count++;
+            if (count == windSize) {
+                break;
+            }
+        }
+        return count == windSize;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/DynamicGraphVertexScanSourceFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/DynamicGraphVertexScanSourceFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.function.graph.source;
+
+import com.antgroup.geaflow.model.graph.meta.GraphMeta;
+import com.antgroup.geaflow.state.DataModel;
+import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
+import com.antgroup.geaflow.state.graph.StateMode;
+import com.antgroup.geaflow.view.graph.GraphViewDesc;
+import java.util.Iterator;
+
+public class DynamicGraphVertexScanSourceFunction<K> extends AbstractVertexScanSourceFunction<K> {
+
+    public DynamicGraphVertexScanSourceFunction(GraphViewDesc graphViewDesc) {
+        super(graphViewDesc);
+    }
+
+    @Override
+    protected Iterator<K> buildIdIterator() {
+        return graphState.dynamicGraph().V().idIterator();
+    }
+
+    @Override
+    protected GraphStateDescriptor<K, ?, ?> buildGraphStateDesc() {
+        GraphStateDescriptor<K, ?, ?> desc =  super.buildGraphStateDesc();
+        desc.withDataModel(DataModel.DYNAMIC_GRAPH);
+        desc.withStateMode(StateMode.RW);
+        desc.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
+        return desc;
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/StaticGraphVertexScanSourceFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/function/graph/source/StaticGraphVertexScanSourceFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.runtime.function.graph.source;
+
+import com.antgroup.geaflow.model.graph.meta.GraphMeta;
+import com.antgroup.geaflow.state.DataModel;
+import com.antgroup.geaflow.state.descriptor.GraphStateDescriptor;
+import com.antgroup.geaflow.state.graph.StateMode;
+import com.antgroup.geaflow.view.graph.GraphViewDesc;
+import java.util.Iterator;
+
+public class StaticGraphVertexScanSourceFunction<K> extends AbstractVertexScanSourceFunction<K> {
+
+    public StaticGraphVertexScanSourceFunction(GraphViewDesc graphViewDesc) {
+        super(graphViewDesc);
+    }
+
+    @Override
+    protected Iterator<K> buildIdIterator() {
+        return graphState.staticGraph().V().idIterator();
+    }
+
+    protected GraphStateDescriptor<K, ?, ?> buildGraphStateDesc() {
+        GraphStateDescriptor<K, ?, ?> desc =  super.buildGraphStateDesc();
+        desc.withDataModel(DataModel.STATIC_GRAPH);
+        desc.withStateMode(StateMode.RW);
+        desc.withGraphMeta(new GraphMeta(graphViewDesc.getGraphMetaType()));
+        return desc;
+    }
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/LdbcTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/LdbcTest.java
@@ -78,6 +78,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_01.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -86,6 +94,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_02.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_02.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -98,6 +114,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_03.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test (enabled = false)
@@ -106,6 +130,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_04.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_04.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -118,6 +150,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_05.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -126,6 +166,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_06.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_06.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -138,6 +186,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_07.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -148,6 +204,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_08.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -156,6 +220,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_09.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_09.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -169,6 +241,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_10.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -177,6 +257,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_11.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_11.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -189,6 +277,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_12.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -197,6 +293,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_13.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_13.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -209,6 +313,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_14.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -217,6 +329,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_15.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_15.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -229,6 +349,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_16.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -237,6 +365,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_17.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_17.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -249,6 +385,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_18.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -257,6 +401,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/bi_19.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_19.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -269,6 +421,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/bi_20.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -277,6 +437,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/is_01.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_01.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -289,6 +457,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_02.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -297,6 +473,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/is_03.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_03.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -309,6 +493,14 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_04.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
@@ -317,6 +509,14 @@ public class LdbcTest {
             .build()
             .withQueryPath("/ldbc/is_05.sql")
             .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_05.sql")
+            .withConfig(testConfig)
+            .withConfig(DSLConfigKeys.GEAFLOW_DSL_TRAVERSAL_SPLIT_ENABLE.getKey(), String.valueOf(true))
             .execute()
             .checkSinkResult();
     }
@@ -329,10 +529,24 @@ public class LdbcTest {
             .withConfig(testConfig)
             .execute()
             .checkSinkResult();
+
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_06.sql")
+            .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
     }
 
     @Test
     public void testLdbcIs_07() throws Exception {
+        QueryTester
+            .build()
+            .withQueryPath("/ldbc/is_07.sql")
+            .withConfig(testConfig)
+            .execute()
+            .checkSinkResult();
+
         QueryTester
             .build()
             .withQueryPath("/ldbc/is_07.sql")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support converting traversal all vertices in the graph to traversal by stream execution. Traversal by stream can divide trigger points into several groups to reduce the number of trigger points in each group and lower the peak memory usage during execution. This can effectively reduce the possibility of GC or OOM, but the trade-off is that the runtime cost may increase rapidly.


### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
