### PR TITLE
[ISSUE-184] Support async submit events.

### DIFF
--- a/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/utils/FutureUtil.java
+++ b/geaflow/geaflow-common/src/main/java/com/antgroup/geaflow/common/utils/FutureUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.common.utils;
+
+import com.antgroup.geaflow.common.exception.GeaflowRuntimeException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class FutureUtil {
+
+    public static <T> List<T> wait(List<Future<T>> futureList) {
+        return wait(futureList, 0);
+    }
+
+    public static <T> List<T> wait(List<Future<T>> futureList, int timeoutMs) {
+        List<T> result = new ArrayList<>();
+        for (Future<T> future : futureList) {
+            try {
+                if (timeoutMs > 0) {
+                    result.add(future.get(timeoutMs, TimeUnit.MILLISECONDS));
+                } else {
+                    result.add(future.get());
+                }
+            } catch (Exception e) {
+                throw new GeaflowRuntimeException(e);
+            }
+        }
+        return result;
+    }
+}

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/container/Container.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/container/Container.java
@@ -38,8 +38,6 @@ public class Container extends AbstractContainer implements IContainer<IEvent, I
     private static final Logger LOGGER = LoggerFactory.getLogger(Container.class);
 
     private static final String CONTAINER_NAME_PREFIX = "container-";
-    private static final String CONTAINER_RPC_THREAD_PREFIX = "container-rpc-executor";
-    private static final int CONTAINER_RPC_THREAD_NUM = 1;
 
     private ContainerContext containerContext;
     private Dispatcher dispatcher;

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/IContainerEndpointRef.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/IContainerEndpointRef.java
@@ -18,13 +18,14 @@ import com.antgroup.geaflow.cluster.protocol.IEvent;
 import com.antgroup.geaflow.cluster.rpc.RpcEndpointRef.RpcCallback;
 import com.antgroup.geaflow.rpc.proto.Container.Response;
 import java.io.Serializable;
+import java.util.concurrent.Future;
 
 public interface IContainerEndpointRef extends Serializable {
 
     /**
      * Process event request.
      */
-    void process(IEvent request);
+    Future<IEvent> process(IEvent request);
 
     /**
      * Process event request with callback.

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcClient.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcClient.java
@@ -46,6 +46,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,8 +98,8 @@ public class RpcClient implements Serializable {
     }
 
     // container endpoint ref
-    public void processContainer(String containerId, IEvent event) {
-        doRpcWithRetry(() -> connectContainer(containerId).process(event), containerId, CONTAINER);
+    public Future processContainer(String containerId, IEvent event) {
+        return doRpcWithRetry(() -> connectContainer(containerId).process(event), containerId, CONTAINER);
     }
 
     public void processContainer(String containerId, IEvent event, RpcCallback<Response> callback) {

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcResponseFuture.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcResponseFuture.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.cluster.rpc;
+
+import com.antgroup.geaflow.cluster.protocol.IEvent;
+import com.antgroup.geaflow.cluster.rpc.impl.RpcMessageEncoder;
+import com.antgroup.geaflow.rpc.proto.Container;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.jetbrains.annotations.NotNull;
+
+public class RpcResponseFuture implements Future<IEvent> {
+
+    private final ListenableFuture<Container.Response> delegate;
+
+    public RpcResponseFuture(ListenableFuture<Container.Response> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return delegate.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return delegate.isDone();
+    }
+
+    @Override
+    public IEvent get() throws InterruptedException, ExecutionException {
+        Container.Response response = delegate.get();
+        return getEvent(response);
+    }
+
+    @Override
+    public IEvent get(long timeout, @NotNull TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        Container.Response response = delegate.get(timeout, unit);
+        return getEvent(response);
+    }
+
+    private IEvent getEvent(Container.Response response) {
+        ByteString payload = response.getPayload();
+        if (payload == null || payload == ByteString.EMPTY) {
+            return null;
+        } else {
+            return RpcMessageEncoder.decode(payload);
+        }
+    }
+}

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/ContainerEndpointRef.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/ContainerEndpointRef.java
@@ -16,6 +16,7 @@ package com.antgroup.geaflow.cluster.rpc.impl;
 
 import com.antgroup.geaflow.cluster.protocol.IEvent;
 import com.antgroup.geaflow.cluster.rpc.IContainerEndpointRef;
+import com.antgroup.geaflow.cluster.rpc.RpcResponseFuture;
 import com.antgroup.geaflow.rpc.proto.Container.Request;
 import com.antgroup.geaflow.rpc.proto.Container.Response;
 import com.antgroup.geaflow.rpc.proto.ContainerServiceGrpc;
@@ -26,6 +27,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 public class ContainerEndpointRef extends AbstractRpcEndpointRef implements IContainerEndpointRef {
 
@@ -43,10 +45,11 @@ public class ContainerEndpointRef extends AbstractRpcEndpointRef implements ICon
     }
 
     @Override
-    public void process(IEvent request) {
+    public Future<IEvent> process(IEvent request) {
         ensureChannelAlive();
-        Request taskEvent = buildRequest(request);
-        blockingStub.process(taskEvent);
+        Request req = buildRequest(request);
+        ListenableFuture<Response> future = stub.process(req);
+        return new RpcResponseFuture(future);
     }
 
     @Override

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/PipelineMasterEndpointRef.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/PipelineMasterEndpointRef.java
@@ -18,6 +18,7 @@ import com.antgroup.geaflow.cluster.protocol.IEvent;
 import com.antgroup.geaflow.cluster.rpc.IPipelineManagerEndpointRef;
 import com.antgroup.geaflow.rpc.proto.Container;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 public class PipelineMasterEndpointRef extends ContainerEndpointRef implements
     IPipelineManagerEndpointRef {
@@ -27,9 +28,10 @@ public class PipelineMasterEndpointRef extends ContainerEndpointRef implements
     }
 
     @Override
-    public void process(IEvent request) {
+    public Future<IEvent> process(IEvent request) {
         ensureChannelAlive();
         Container.Request taskEvent = buildRequest(request);
         blockingStub.process(taskEvent);
+        return null;
     }
 }

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/java/com/antgroup/geaflow/cluster/rpc/AsyncRpcTest.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/java/com/antgroup/geaflow/cluster/rpc/AsyncRpcTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.cluster.rpc;
+
+import com.antgroup.geaflow.cluster.protocol.EventType;
+import com.antgroup.geaflow.cluster.protocol.IEvent;
+import com.antgroup.geaflow.cluster.rpc.impl.ContainerEndpointRef;
+import com.antgroup.geaflow.cluster.rpc.impl.RpcMessageEncoder;
+import com.antgroup.geaflow.cluster.rpc.impl.RpcServiceImpl;
+import com.antgroup.geaflow.common.config.Configuration;
+import com.antgroup.geaflow.common.exception.GeaflowRuntimeException;
+import com.antgroup.geaflow.common.utils.ProcessUtil;
+import com.antgroup.geaflow.common.utils.ReflectionUtil;
+import com.antgroup.geaflow.common.utils.SleepUtils;
+import com.antgroup.geaflow.rpc.proto.ContainerServiceGrpc;
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AsyncRpcTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncRpcTest.class);
+
+    @Test
+    public void testAsyncRpc() throws Exception {
+
+        Server server = new Server();
+        server.startServer();
+        ExecutorService  executorService = Executors.newFixedThreadPool(1);
+        String host = ProcessUtil.getHostIp();
+        ContainerEndpointRef client = new ContainerEndpointRef(host, server.rpcPort, executorService);
+
+        int eventCount = 100;
+        List<IEvent> request = new ArrayList<>();
+        List<Future<IEvent>> events = new ArrayList<>();
+        for (int i = 0; i < eventCount; i++) {
+            IEvent event = new TestEvent(i);
+            request.add(event);
+            events.add(client.process(event));
+        }
+        validateResult(events, eventCount, 5000);
+        LOGGER.info("send event finish");
+    }
+
+    @Test(expectedExceptions = ExecutionException.class)
+    public void testShutdownChannel() throws Exception {
+
+        Server server = new Server();
+        server.startServer();
+        ExecutorService  executorService = Executors.newFixedThreadPool(1);
+        String host = ProcessUtil.getHostIp();
+        ContainerEndpointRef client = new ContainerEndpointRef(host, server.rpcPort, executorService);
+
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                SleepUtils.sleepMilliSecond(300);
+                LOGGER.info("shutdown channel");
+                ManagedChannel channel = (ManagedChannel) ReflectionUtil.getField(client, "channel");
+                channel.shutdownNow();
+                LOGGER.info("shutdown channel finish ");
+            }
+        });
+        thread.start();
+
+        int eventCount = 1000;
+        List<IEvent> request = new ArrayList<>();
+        List<Future<IEvent>> events = new ArrayList<>();
+        for (int i = 0; i < eventCount; i++) {
+            TestEvent event = new TestEvent(i);
+            request.add(event);
+            event.processTimeMs = 100;
+            SleepUtils.sleepMilliSecond(1);
+            if (i % 100 == 0) {
+            }
+            events.add(client.process(event));
+        }
+        validateResult(events, eventCount, 5000);
+        LOGGER.info("send event finish");
+    }
+
+    @Test(expectedExceptions = ExecutionException.class)
+    public void testServerError() throws Exception {
+
+        Server server = new Server();
+        server.startServer();
+        ExecutorService  executorService = Executors.newFixedThreadPool(1);
+        String host = ProcessUtil.getHostIp();
+        ContainerEndpointRef client = new ContainerEndpointRef(host, server.rpcPort, executorService);
+
+        int eventCount = 100;
+        List<Future<IEvent>> results = new ArrayList<>();
+        for (int i = 0; i < eventCount; i++) {
+            TestEvent event = new TestEvent(i);
+            if (i == 50) {
+                event.isException = true;
+            }
+            results.add(client.process(event));
+        }
+        LOGGER.info("send event finish");
+        validateResult(results, eventCount, 5000);
+    }
+
+    public void validateResult(List<Future<IEvent>> results, int count, int waitTimeMs) throws Exception {
+        List<Integer> eventIds = new ArrayList<>();
+        List<Integer> processedIds = new ArrayList<>();
+        LOGGER.info("validate result");
+        for (int i = 0; i < count; i++) {
+            eventIds.add(i);
+            processedIds.add(((TestEvent) (results.get(i).get(waitTimeMs, TimeUnit.MILLISECONDS))).id);
+        }
+        Assert.assertEquals(processedIds, eventIds);
+        LOGGER.info("validate finish");
+    }
+
+    /**
+     * Mock event with dummy info.
+     */
+    public class TestEvent implements IEvent {
+        private int id;
+        private int processTimeMs;
+        private boolean isException;
+
+        public TestEvent(int id) {
+            this.id = id;
+        }
+
+
+        @Override
+        public EventType getEventType() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "TestEvent{" +
+                "id=" + id +
+                '}';
+        }
+    }
+
+    public class Server {
+
+        protected int rpcPort;
+
+        protected Configuration configuration = new Configuration();
+        protected RpcServiceImpl rpcService;
+
+        public void startServer() {
+            this.rpcService = new RpcServiceImpl(0, configuration);
+            this.rpcService.addEndpoint(new MockContainerEndpoint());
+            this.rpcPort = rpcService.startService();
+        }
+
+        public void stopServer() {
+            rpcService.stopService();
+        }
+    }
+
+    /**
+     * Mock endpoint to process events.
+     */
+    public class MockContainerEndpoint extends ContainerServiceGrpc.ContainerServiceImplBase implements
+        RpcEndpoint {
+
+        public MockContainerEndpoint() {
+        }
+
+        public void process(com.antgroup.geaflow.rpc.proto.Container.Request request,
+                            StreamObserver<com.antgroup.geaflow.rpc.proto.Container.Response> responseObserver) {
+            try {
+                IEvent event = RpcMessageEncoder.decode(request.getPayload());
+                if (((TestEvent) event).processTimeMs > 0) {
+                    SleepUtils.sleepMilliSecond(((TestEvent) event).processTimeMs);
+                }
+                if (((TestEvent) event).isException) {
+                    LOGGER.info("on error: mock exception");
+                    responseObserver.onError(new GeaflowRuntimeException("occur mock exception"));
+                } else {
+                    com.antgroup.geaflow.rpc.proto.Container.Response.Builder builder = com.antgroup.geaflow.rpc.proto.Container.Response.newBuilder();
+                    builder.setPayload(request.getPayload());
+                    responseObserver.onNext(builder.build());
+                    responseObserver.onCompleted();
+                }
+            } catch (Throwable t) {
+                LOGGER.error("process request failed: {}", t.getMessage(), t);
+                responseObserver.onError(t);
+            }
+        }
+
+        public void close(Empty request,
+                          StreamObserver<Empty> responseObserver) {
+            try {
+                LOGGER.info("close");
+                responseObserver.onNext(Empty.newBuilder().build());
+                responseObserver.onCompleted();
+            } catch (Throwable t) {
+                LOGGER.error("close failed: {}", t.getMessage(), t);
+                responseObserver.onError(t);
+            }
+        }
+    }
+
+}

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/resources/log4j.properties
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/resources/log4j.properties
@@ -3,4 +3,4 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %t %c{1}:%L - %m%n

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleScheduler.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleScheduler.java
@@ -47,6 +47,7 @@ import com.antgroup.geaflow.shuffle.message.ShuffleId;
 import com.antgroup.geaflow.shuffle.service.IShuffleMaster;
 import com.antgroup.geaflow.shuffle.service.ShuffleManager;
 import com.antgroup.geaflow.stats.collector.StatsCollectorFactory;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/BaseCycleSchedulerTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/BaseCycleSchedulerTest.java
@@ -31,6 +31,7 @@ import com.antgroup.geaflow.runtime.core.protocol.DoneEvent;
 import com.antgroup.geaflow.runtime.core.protocol.LaunchSourceEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -67,7 +68,9 @@ public class BaseCycleSchedulerTest {
         // mock container rpc
         Mockito.doAnswer(in -> {
             processor.process((IEvent) in.getArgument(1));
-            return null;
+            CompletableFuture future = new CompletableFuture<>();
+            future.complete(null);
+            return future;
         }).when(rpcClient).processContainer(any(), any());
 
         Mockito.doAnswer(in -> {


### PR DESCRIPTION
### What changes were proposed in this pull request?
使用独立的rpc不能保证有序，在rpc server端可能接收到乱序，如果在一组rpc请求内，允许乱序，而不同组直接通过同步等待，保证严格有序即可。
在scheduler每一轮发送的一组event，对于发给单个worker的event，已经合并到ComposeEvent中，不同event是发给不同的worker的，也即这些event可以允许乱序，在运行时表现为不同worker收到event时间先后顺序不同而已。
当一组event发送完成后，同步等待所有event的响应，直到确认所有event的回应后，才继续执行。

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
