### PR TITLE
[ISSUE-214] Support different names for vertex and edge meta fields 

### DIFF
--- a/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraph.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-catalog/src/main/java/com/antgroup/geaflow/dsl/schema/GeaFlowGraph.java
@@ -90,9 +90,7 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
         if (this.vertexTables.size() > 0) {
             TableField commonVertexIdField = this.vertexTables.get(0).getIdField();
             for (VertexTable vertexTable : this.vertexTables) {
-                if (!vertexTable.getIdFieldName().equals(commonVertexIdField.getName())) {
-                    throw new GeaFlowDSLException("Id field name should be same between vertex " + "tables");
-                } else if (!vertexTable.getIdField().getType().equals(commonVertexIdField.getType())) {
+                if (!vertexTable.getIdField().getType().equals(commonVertexIdField.getType())) {
                     throw new GeaFlowDSLException("Id field type should be same between vertex " + "tables");
                 }
             }
@@ -103,15 +101,9 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
             Optional<TableField> commonTsField =
                 Optional.ofNullable(this.edgeTables.get(0).getTimestampField());
             for (EdgeTable edgeTable : this.edgeTables) {
-                if (!edgeTable.getSrcIdFieldName().equals(commonSrcIdField.getName())) {
-                    throw new GeaFlowDSLException("SOURCE ID field name should be same between "
-                        + "edge tables");
-                } else if (!edgeTable.getSrcIdField().getType().equals(commonSrcIdField.getType())) {
+                if (!edgeTable.getSrcIdField().getType().equals(commonSrcIdField.getType())) {
                     throw new GeaFlowDSLException("SOURCE ID field type should be same between edge "
                         + "tables");
-                } else if (!edgeTable.getTargetIdFieldName().equals(commonTargetIdField.getName())) {
-                    throw new GeaFlowDSLException("DESTINATION ID field name should be same "
-                        + "between edge tables");
                 } else if (!edgeTable.getTargetIdField().getType().equals(commonTargetIdField.getType())) {
                     throw new GeaFlowDSLException("DESTINATION ID field type should be same "
                         + "between edge tables");
@@ -120,9 +112,6 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
                 if (commonTsField.isPresent()) {
                     if (edgeTable.getTimestampField() == null) {
                         throw new GeaFlowDSLException("TIMESTAMP should defined or not defined in all edge tables");
-                    } else if (!edgeTable.getTimestampFieldName().equals(commonTsField.get().getName())) {
-                        throw new GeaFlowDSLException("TIMESTAMP field name should be same between "
-                            + "edge tables");
                     } else if (!edgeTable.getTimestampField().getType().equals(commonTsField.get().getType())) {
                         throw new GeaFlowDSLException("TIMESTAMP field type should be same between edge "
                             + "tables");
@@ -307,6 +296,9 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
         }
 
         private void checkFields() {
+            for (TableField field : getFields()) {
+                GraphRecordType.validateFieldName(field.getName());
+            }
             Set<String> fieldNames = getFields().stream().map(TableField::getName)
                 .collect(Collectors.toSet());
             if (fieldNames.size() != super.getFields().size()) {
@@ -378,6 +370,9 @@ public class GeaFlowGraph extends AbstractTable implements Serializable {
         }
 
         private void checkFields() {
+            for (TableField field : getFields()) {
+                GraphRecordType.validateFieldName(field.getName());
+            }
             Set<String> fieldNames = getFields().stream().map(TableField::getName)
                 .collect(Collectors.toSet());
             if (fieldNames.size() != getFields().size()) {

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/exception/GeaFlowDSLException.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/exception/GeaFlowDSLException.java
@@ -27,6 +27,10 @@ public class GeaFlowDSLException extends RuntimeException {
         super(message);
     }
 
+    public GeaFlowDSLException(Throwable e, String message, Object... parameters) {
+        super(MessageFormatter.arrayFormat(message, parameters).getMessage(), e);
+    }
+
     public GeaFlowDSLException(SqlParserPos position, String message, Object... parameters) {
         super("At " + position + ": " + MessageFormatter.arrayFormat(message, parameters).getMessage());
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/types/EdgeType.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/types/EdgeType.java
@@ -48,6 +48,8 @@ public class EdgeType extends StructType {
 
     public static final String DEFAULT_LABEL_NAME = "~label";
 
+    public static final String DEFAULT_TS_NAME = "~ts";
+
     public EdgeType(List<TableField> fields, boolean hasTimestamp) {
         super(fields);
         this.hasTimestamp = hasTimestamp;

--- a/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/types/VertexType.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-common/src/main/java/com/antgroup/geaflow/dsl/common/types/VertexType.java
@@ -33,6 +33,8 @@ public class VertexType extends StructType {
 
     private static final int NUM_META_FIELDS = 2;
 
+    public static final String DEFAULT_ID_FIELD_NAME = "~id";
+
     public VertexType(List<TableField> fields) {
         super(fields);
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-parser/src/main/java/com/antgroup/geaflow/dsl/calcite/EdgeRecordType.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-parser/src/main/java/com/antgroup/geaflow/dsl/calcite/EdgeRecordType.java
@@ -51,6 +51,31 @@ public class EdgeRecordType extends RelRecordType {
     public static EdgeRecordType createEdgeType(List<RelDataTypeField> fields, String srcIdField,
                                                 String targetIdField, String timestampField,
                                                 RelDataTypeFactory typeFactory) {
+
+        boolean hasMultiSrcIdFields = fields.stream()
+            .filter(f -> f.getType() instanceof MetaFieldType
+                && ((MetaFieldType) f.getType()).getMetaField().equals(MetaField.EDGE_SRC_ID))
+            .count() > 1;
+        if (hasMultiSrcIdFields) {
+            srcIdField = EdgeType.DEFAULT_SRC_ID_NAME;
+            fields = GraphRecordType.renameMetaField(fields, MetaField.EDGE_SRC_ID, srcIdField);
+        }
+        boolean hasMultiTargetIdFields = fields.stream()
+            .filter(f -> f.getType() instanceof MetaFieldType
+                && ((MetaFieldType) f.getType()).getMetaField().equals(MetaField.EDGE_TARGET_ID))
+            .count() > 1;
+        if (hasMultiTargetIdFields) {
+            targetIdField = EdgeType.DEFAULT_TARGET_ID_NAME;
+            fields = GraphRecordType.renameMetaField(fields, MetaField.EDGE_TARGET_ID, targetIdField);
+        }
+        boolean hasMultiTsFields = fields.stream()
+            .filter(f -> f.getType() instanceof MetaFieldType
+                && ((MetaFieldType) f.getType()).getMetaField().equals(MetaField.EDGE_TS))
+            .count() > 1;
+        if (hasMultiTsFields) {
+            timestampField = EdgeType.DEFAULT_TS_NAME;
+            fields = GraphRecordType.renameMetaField(fields, MetaField.EDGE_TS, timestampField);
+        }
         List<RelDataTypeField> reorderFields = reorderFields(fields, srcIdField, targetIdField, timestampField,
             typeFactory);
         return new EdgeRecordType(reorderFields, timestampField != null);

--- a/geaflow/geaflow-dsl/geaflow-dsl-parser/src/main/java/com/antgroup/geaflow/dsl/calcite/VertexRecordType.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-parser/src/main/java/com/antgroup/geaflow/dsl/calcite/VertexRecordType.java
@@ -44,6 +44,12 @@ public class VertexRecordType extends RelRecordType {
 
     public static VertexRecordType createVertexType(List<RelDataTypeField> fields, String idField,
                                                     RelDataTypeFactory typeFactory) {
+        boolean hasMultiIdFields = fields.stream().filter(f -> f.getType() instanceof MetaFieldType
+            && ((MetaFieldType) f.getType()).getMetaField().equals(MetaField.VERTEX_ID)).count() > 1;
+        if (hasMultiIdFields) {
+            idField = VertexType.DEFAULT_ID_FIELD_NAME;
+            fields = GraphRecordType.renameMetaField(fields, MetaField.VERTEX_ID, idField);
+        }
         List<RelDataTypeField> reorderFields = reorderFields(fields, idField, typeFactory);
         return new VertexRecordType(reorderFields);
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/schema/function/BuildInSqlFunctionTable.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/schema/function/BuildInSqlFunctionTable.java
@@ -46,8 +46,12 @@ import com.antgroup.geaflow.dsl.udf.table.date.Year;
 import com.antgroup.geaflow.dsl.udf.table.math.E;
 import com.antgroup.geaflow.dsl.udf.table.math.Log2;
 import com.antgroup.geaflow.dsl.udf.table.math.Round;
+import com.antgroup.geaflow.dsl.udf.table.other.EdgeSrcId;
+import com.antgroup.geaflow.dsl.udf.table.other.EdgeTargetId;
+import com.antgroup.geaflow.dsl.udf.table.other.EdgeTimestamp;
 import com.antgroup.geaflow.dsl.udf.table.other.If;
 import com.antgroup.geaflow.dsl.udf.table.other.Label;
+import com.antgroup.geaflow.dsl.udf.table.other.VertexId;
 import com.antgroup.geaflow.dsl.udf.table.string.Ascii2String;
 import com.antgroup.geaflow.dsl.udf.table.string.Base64Decode;
 import com.antgroup.geaflow.dsl.udf.table.string.Base64Encode;
@@ -158,6 +162,10 @@ public class BuildInSqlFunctionTable extends ListSqlOperatorTable {
             // udf.table.other
             .add(GeaFlowFunction.of(If.class))
             .add(GeaFlowFunction.of(Label.class))
+            .add(GeaFlowFunction.of(VertexId.class))
+            .add(GeaFlowFunction.of(EdgeSrcId.class))
+            .add(GeaFlowFunction.of(EdgeTargetId.class))
+            .add(GeaFlowFunction.of(EdgeTimestamp.class))
             // UDGA
             .add(GeaFlowFunction.of(SingleSourceShortestPath.class))
             .add(GeaFlowFunction.of(PageRank.class))

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeSrcId.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeSrcId.java
@@ -14,28 +14,22 @@
 
 package com.antgroup.geaflow.dsl.udf.table.other;
 
-import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
-import com.antgroup.geaflow.dsl.common.data.RowVertex;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
 import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
 import com.antgroup.geaflow.dsl.util.GraphSchemaUtil;
 import org.apache.calcite.rel.type.RelDataType;
 
-@Description(name = "label", description = "Returns label for edge or vertex")
-public class Label extends UDF implements GraphMetaFieldAccessFunction {
+@Description(name = "srcId", description = "Returns srcId for edge")
+public class EdgeSrcId extends UDF implements GraphMetaFieldAccessFunction {
 
-    public BinaryString eval(RowEdge edge) {
-        return edge.getBinaryLabel();
-    }
-
-    public BinaryString eval(RowVertex vertex) {
-        return vertex.getBinaryLabel();
+    public Object eval(RowEdge edge) {
+        return edge.getSrcId();
     }
 
     @Override
     public RelDataType getReturnRelDataType(GQLJavaTypeFactory typeFactory) {
-        return GraphSchemaUtil.getCurrentGraphLabelType(typeFactory);
+        return GraphSchemaUtil.getCurrentGraphEdgeSrcIdType(typeFactory);
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeTargetId.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeTargetId.java
@@ -14,28 +14,22 @@
 
 package com.antgroup.geaflow.dsl.udf.table.other;
 
-import com.antgroup.geaflow.common.binary.BinaryString;
 import com.antgroup.geaflow.dsl.common.data.RowEdge;
-import com.antgroup.geaflow.dsl.common.data.RowVertex;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
 import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
 import com.antgroup.geaflow.dsl.util.GraphSchemaUtil;
 import org.apache.calcite.rel.type.RelDataType;
 
-@Description(name = "label", description = "Returns label for edge or vertex")
-public class Label extends UDF implements GraphMetaFieldAccessFunction {
+@Description(name = "targetId", description = "Returns targetId for edge")
+public class EdgeTargetId extends UDF implements GraphMetaFieldAccessFunction {
 
-    public BinaryString eval(RowEdge edge) {
-        return edge.getBinaryLabel();
-    }
-
-    public BinaryString eval(RowVertex vertex) {
-        return vertex.getBinaryLabel();
+    public Object eval(RowEdge edge) {
+        return edge.getTargetId();
     }
 
     @Override
     public RelDataType getReturnRelDataType(GQLJavaTypeFactory typeFactory) {
-        return GraphSchemaUtil.getCurrentGraphLabelType(typeFactory);
+        return GraphSchemaUtil.getCurrentGraphEdgeTargetIdType(typeFactory);
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeTimestamp.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/EdgeTimestamp.java
@@ -14,28 +14,27 @@
 
 package com.antgroup.geaflow.dsl.udf.table.other;
 
-import com.antgroup.geaflow.common.binary.BinaryString;
-import com.antgroup.geaflow.dsl.common.data.RowEdge;
-import com.antgroup.geaflow.dsl.common.data.RowVertex;
+import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
 import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
 import com.antgroup.geaflow.dsl.util.GraphSchemaUtil;
+import com.antgroup.geaflow.model.graph.IGraphElementWithTimeField;
 import org.apache.calcite.rel.type.RelDataType;
 
-@Description(name = "label", description = "Returns label for edge or vertex")
-public class Label extends UDF implements GraphMetaFieldAccessFunction {
+@Description(name = "ts", description = "Returns ts for edge with timestamp")
+public class EdgeTimestamp extends UDF implements GraphMetaFieldAccessFunction {
 
-    public BinaryString eval(RowEdge edge) {
-        return edge.getBinaryLabel();
-    }
-
-    public BinaryString eval(RowVertex vertex) {
-        return vertex.getBinaryLabel();
+    public Long eval(IGraphElementWithTimeField edge) {
+        return edge.getTime();
     }
 
     @Override
     public RelDataType getReturnRelDataType(GQLJavaTypeFactory typeFactory) {
-        return GraphSchemaUtil.getCurrentGraphLabelType(typeFactory);
+        if (GraphSchemaUtil.getCurrentGraphEdgeTimestampType(typeFactory).isPresent()) {
+            return GraphSchemaUtil.getCurrentGraphEdgeTimestampType(typeFactory).get();
+        } else {
+            throw new GeaFlowDSLException("Cannot find timestamp type");
+        }
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/GraphMetaFieldAccessFunction.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/GraphMetaFieldAccessFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.udf.table.other;
+
+import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
+import org.apache.calcite.rel.type.RelDataType;
+
+public interface GraphMetaFieldAccessFunction {
+
+    RelDataType getReturnRelDataType(GQLJavaTypeFactory typeFactory);
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/VertexId.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/udf/table/other/VertexId.java
@@ -14,8 +14,6 @@
 
 package com.antgroup.geaflow.dsl.udf.table.other;
 
-import com.antgroup.geaflow.common.binary.BinaryString;
-import com.antgroup.geaflow.dsl.common.data.RowEdge;
 import com.antgroup.geaflow.dsl.common.data.RowVertex;
 import com.antgroup.geaflow.dsl.common.function.Description;
 import com.antgroup.geaflow.dsl.common.function.UDF;
@@ -23,19 +21,15 @@ import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
 import com.antgroup.geaflow.dsl.util.GraphSchemaUtil;
 import org.apache.calcite.rel.type.RelDataType;
 
-@Description(name = "label", description = "Returns label for edge or vertex")
-public class Label extends UDF implements GraphMetaFieldAccessFunction {
+@Description(name = "id", description = "Returns id for vertex")
+public class VertexId extends UDF implements GraphMetaFieldAccessFunction {
 
-    public BinaryString eval(RowEdge edge) {
-        return edge.getBinaryLabel();
-    }
-
-    public BinaryString eval(RowVertex vertex) {
-        return vertex.getBinaryLabel();
+    public Object eval(RowVertex vertex) {
+        return vertex.getId();
     }
 
     @Override
     public RelDataType getReturnRelDataType(GQLJavaTypeFactory typeFactory) {
-        return GraphSchemaUtil.getCurrentGraphLabelType(typeFactory);
+        return GraphSchemaUtil.getCurrentGraphVertexIdType(typeFactory);
     }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/util/FunctionUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/util/FunctionUtil.java
@@ -28,6 +28,7 @@ import com.antgroup.geaflow.dsl.schema.function.GeaFlowUserDefinedAggFunction;
 import com.antgroup.geaflow.dsl.schema.function.GeaFlowUserDefinedGraphAlgorithm;
 import com.antgroup.geaflow.dsl.schema.function.GeaFlowUserDefinedScalarFunction;
 import com.antgroup.geaflow.dsl.schema.function.GeaFlowUserDefinedTableFunction;
+import com.antgroup.geaflow.dsl.udf.table.other.GraphMetaFieldAccessFunction;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -172,6 +173,19 @@ public class FunctionUtil {
                 SqlTypeUtil.convertToJavaTypes(opBinding.collectOperandTypes(), typeFactory);
 
             Method method = FunctionCallUtils.findMatchMethod(clazz, functionName, paramJavaTypes);
+            if (GraphMetaFieldAccessFunction.class.isAssignableFrom(clazz)) {
+                Class<?> returnClazz = method.getReturnType();
+                if (returnClazz.equals(Object.class)) {
+                    try {
+                        GraphMetaFieldAccessFunction func =
+                            ((GraphMetaFieldAccessFunction)clazz.newInstance());
+                        return func.getReturnRelDataType((GQLJavaTypeFactory) typeFactory);
+                    } catch (Exception e) {
+                        throw new GeaFlowDSLException(e,
+                            "Cannot get instance of {}", clazz.getName());
+                    }
+                }
+            }
             return typeFactory.createType(method.getReturnType());
         };
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/util/GraphSchemaUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/main/java/com/antgroup/geaflow/dsl/util/GraphSchemaUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 AntGroup CO., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package com.antgroup.geaflow.dsl.util;
+
+import com.antgroup.geaflow.dsl.common.exception.GeaFlowDSLException;
+import com.antgroup.geaflow.dsl.planner.GQLJavaTypeFactory;
+import java.util.Optional;
+import org.apache.calcite.rel.type.RelDataType;
+
+public class GraphSchemaUtil {
+
+    public static RelDataType getCurrentGraphVertexIdType(GQLJavaTypeFactory typeFactory) {
+        if (typeFactory.getCurrentGraph() == null) {
+            throw new GeaFlowDSLException("Cannot get vertex id type without setting current graph");
+        } else if (typeFactory.getCurrentGraph().getVertexTables().isEmpty()) {
+            throw new GeaFlowDSLException("No vertex table found in current graph {}", typeFactory.getCurrentGraph());
+        } else {
+            return typeFactory.getCurrentGraph().getVertexTables().get(0).getRowType(typeFactory).getIdField().getType();
+        }
+    }
+
+    public static RelDataType getCurrentGraphEdgeSrcIdType(GQLJavaTypeFactory typeFactory) {
+        if (typeFactory.getCurrentGraph() == null) {
+            throw new GeaFlowDSLException("Cannot get edge src id type without setting current graph");
+        } else if (typeFactory.getCurrentGraph().getEdgeTables().isEmpty()) {
+            throw new GeaFlowDSLException("No edge table found in current graph {}", typeFactory.getCurrentGraph());
+        } else {
+            return typeFactory.getCurrentGraph().getEdgeTables().get(0).getRowType(typeFactory).getSrcIdField().getType();
+        }
+    }
+
+    public static RelDataType getCurrentGraphEdgeTargetIdType(GQLJavaTypeFactory typeFactory) {
+        if (typeFactory.getCurrentGraph() == null) {
+            throw new GeaFlowDSLException("Cannot get edge target id type without setting current graph");
+        } else if (typeFactory.getCurrentGraph().getEdgeTables().isEmpty()) {
+            throw new GeaFlowDSLException("No edge table found in current graph {}", typeFactory.getCurrentGraph());
+        } else {
+            return typeFactory.getCurrentGraph().getEdgeTables().get(0).getRowType(typeFactory).getTargetIdField().getType();
+        }
+    }
+
+    public static RelDataType getCurrentGraphLabelType(GQLJavaTypeFactory typeFactory) {
+        if (typeFactory.getCurrentGraph() == null) {
+            throw new GeaFlowDSLException("Cannot get label type without setting current graph");
+        } else if (!typeFactory.getCurrentGraph().getVertexTables().isEmpty()) {
+            return typeFactory.getCurrentGraph().getVertexTables().get(0).getRowType(typeFactory)
+                .getLabelField().getType();
+        } else if (!typeFactory.getCurrentGraph().getEdgeTables().isEmpty()) {
+            return typeFactory.getCurrentGraph().getEdgeTables().get(0).getRowType(typeFactory)
+                .getLabelField().getType();
+        } else {
+            throw new GeaFlowDSLException("No vertex or edge table found in current graph {}", typeFactory.getCurrentGraph());
+        }
+    }
+
+    public static Optional<RelDataType> getCurrentGraphEdgeTimestampType(GQLJavaTypeFactory typeFactory) {
+        if (typeFactory.getCurrentGraph() == null) {
+            throw new GeaFlowDSLException("Cannot get edge ts type without setting current graph");
+        } else if (typeFactory.getCurrentGraph().getEdgeTables().isEmpty()) {
+            throw new GeaFlowDSLException("No edge table found in current graph {}", typeFactory.getCurrentGraph());
+        } else if (typeFactory.getCurrentGraph().getEdgeTables().get(0).getRowType(typeFactory).getTimestampField().isPresent()) {
+            return Optional.of(typeFactory.getCurrentGraph().getEdgeTables().get(0).getRowType(typeFactory)
+                .getTimestampField().get().getType());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/GQLValidateGraphRecordTypeTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-plan/src/test/java/com/antgroup/geaflow/dsl/GQLValidateGraphRecordTypeTest.java
@@ -85,7 +85,7 @@ public class GQLValidateGraphRecordTypeTest {
             .expectException("Same name field between edge tables shouldn't have different type.");
     }
 
-    @Test
+    @Test (enabled = false)
     public void testSameIdFieldNameValidation() {
         String graphDDL = "create graph g1("
             + "vertex user("
@@ -116,7 +116,7 @@ public class GQLValidateGraphRecordTypeTest {
             .expectException("Id field name should be same between vertex tables");
     }
 
-    @Test
+    @Test (enabled = false)
     public void testSameSourceIdFieldNameValidation() {
         String graphDDL = "create graph g1("
             + "vertex user("
@@ -146,7 +146,7 @@ public class GQLValidateGraphRecordTypeTest {
             .expectException("SOURCE ID field name should be same between edge tables");
     }
 
-    @Test
+    @Test (enabled = false)
     public void testSameDestinationIdFieldNameValidation() {
         String graphDDL = "create graph g1("
             + "vertex user("
@@ -178,7 +178,7 @@ public class GQLValidateGraphRecordTypeTest {
     }
 
 
-    @Test
+    @Test (enabled = false)
     public void testSameTimestampFieldNameValidation() {
         String graphDDL = "create graph g1("
             + "vertex user("

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/SchemaUtil.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/main/java/com/antgroup/geaflow/dsl/runtime/util/SchemaUtil.java
@@ -121,6 +121,27 @@ public class SchemaUtil {
         for (int i = 0; i < outputType.size(); i++) {
             String outputField = outputType.getField(i).getName();
             mapping[i] = inputType.indexOf(outputField);
+            if (mapping[i] < 0) {
+                switch (outputField) {
+                    case VertexType.DEFAULT_ID_FIELD_NAME:
+                        mapping[i] = VertexType.ID_FIELD_POSITION;
+                        break;
+                    case EdgeType.DEFAULT_SRC_ID_NAME:
+                        mapping[i] = EdgeType.SRC_ID_FIELD_POSITION;
+                        break;
+                    case EdgeType.DEFAULT_TARGET_ID_NAME:
+                        mapping[i] = EdgeType.TARGET_ID_FIELD_POSITION;
+                        break;
+                    case EdgeType.DEFAULT_TS_NAME:
+                        mapping[i] = EdgeType.TIME_FIELD_POSITION;
+                        break;
+                    default:
+                        if (mapping[i] < -1) {
+                            throw new GeaFlowDSLException("Cannot find field {}, illegal index {}",
+                                outputField, mapping[i]);
+                        }
+                }
+            }
         }
         return mapping;
     }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/GQLMatchTest.java
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/java/com/antgroup/geaflow/dsl/runtime/query/GQLMatchTest.java
@@ -124,4 +124,13 @@ public class GQLMatchTest {
             .execute()
             .checkSinkResult();
     }
+
+    @Test
+    public void testMatch_012() throws Exception {
+        QueryTester
+            .build()
+            .withQueryPath("/query/gql_match_012.sql")
+            .execute()
+            .checkSinkResult();
+    }
 }

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/expect/gql_match_012.txt
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/expect/gql_match_012.txt
@@ -1,0 +1,6 @@
+3,3,3,1,1,1,software,created
+5,5,5,4,4,4,software,created
+3,3,3,4,4,4,software,created
+4,4,4,1,1,1,person,knows
+2,2,2,1,1,1,person,knows
+3,3,3,6,6,6,software,created

--- a/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/gql_match_012.sql
+++ b/geaflow/geaflow-dsl/geaflow-dsl-runtime/src/test/resources/query/gql_match_012.sql
@@ -1,0 +1,83 @@
+CREATE TABLE v_person (
+  name varchar,
+  age int,
+  personId bigint
+) WITH (
+	type='file',
+	geaflow.dsl.window.size = -1,
+	geaflow.dsl.file.path = 'resource:///data/modern_vertex_person_reorder.txt'
+);
+
+CREATE TABLE v_software (
+  name varchar,
+  lang varchar,
+  softwareId bigint
+) WITH (
+	type='file',
+	geaflow.dsl.window.size = -1,
+	geaflow.dsl.file.path = 'resource:///data/modern_vertex_software_reorder.txt'
+);
+
+CREATE TABLE e_knows (
+  knowsSrc bigint,
+  knowsTarget bigint,
+  weight double
+) WITH (
+	type='file',
+	geaflow.dsl.window.size = -1,
+	geaflow.dsl.file.path = 'resource:///data/modern_edge_knows.txt'
+);
+
+CREATE TABLE e_created (
+  createdSource bigint,
+  createdTarget bigint,
+  weight double
+) WITH (
+	type='file',
+	geaflow.dsl.window.size = -1,
+	geaflow.dsl.file.path = 'resource:///data/modern_edge_created.txt'
+);
+
+CREATE GRAPH modern (
+	Vertex person using v_person WITH ID(personId),
+	Vertex software using v_software WITH ID(softwareId),
+	Edge knows using e_knows WITH ID(knowsSrc, knowsTarget),
+	Edge created using e_created WITH ID(createdSource, createdTarget)
+) WITH (
+	storeType='memory',
+	shardCount = 2
+);
+
+CREATE TABLE tbl_result (
+  a_id bigint,
+  a_id2 bigint,
+  srcId bigint,
+  targetId bigint,
+  b_id bigint,
+  b_id2 bigint,
+  vLabel varchar,
+  eLabel varchar
+) WITH (
+	type='file',
+	geaflow.dsl.file.path='${target}'
+);
+
+USE GRAPH modern;
+
+INSERT INTO tbl_result
+SELECT
+	a_id,
+  a_id2,
+  srcId,
+  targetId,
+  b_id,
+  b_id2,
+  vLabel,
+  eLabel
+FROM (
+  MATCH (a:person) <-[e]-(b) |+| (a:software) <-[e]-(b)
+  RETURN id(a) as a_id, a.~id as a_id2,
+  srcId(e) as srcId, targetId(e) as targetId,
+  id(b) as b_id, b.~id as b_id2,
+  label(a) as vLabel, label(e) as eLabel
+);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, due to the presence of the union operation, the constraint for the meta fields of graph vertices and edges is that all vertex IDs must have the same name, and all edge source, destination, and timestamps must have the same name. This constraint is clearly too strong, and it is necessary to support meta fields with different names.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
