### PR TITLE
[ISSUE-227] Drivers and containers check and register heartbeat after failover

### DIFF
--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/clustermanager/AbstractClusterManager.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/clustermanager/AbstractClusterManager.java
@@ -223,11 +223,11 @@ public abstract class AbstractClusterManager implements IClusterManager {
     }
 
     public Map<Integer, ContainerInfo> getContainerInfos() {
-        return new HashMap<>(containerInfos);
+        return containerInfos;
     }
 
     public Map<Integer, DriverInfo> getDriverInfos() {
-        return new HashMap<>(driverInfos);
+        return driverInfos;
     }
 
     public Map<Integer, String> getContainerIds() {

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/common/AbstractContainer.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/common/AbstractContainer.java
@@ -48,7 +48,7 @@ public abstract class AbstractContainer extends AbstractComponent {
     }
 
     protected void registerToMaster() {
-        this.heartbeatClient.registerToMaster(masterId, buildComponentInfo());
+        this.heartbeatClient.init(masterId, buildComponentInfo());
     }
 
     @Override

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/heartbeat/HeartbeatSender.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/heartbeat/HeartbeatSender.java
@@ -18,12 +18,12 @@ import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.HEARTB
 import static com.antgroup.geaflow.common.config.keys.ExecutionConfigKeys.HEARTBEAT_INTERVAL_MS;
 
 import com.antgroup.geaflow.cluster.rpc.RpcClient;
-import com.antgroup.geaflow.cluster.rpc.RpcEndpointRef;
+import com.antgroup.geaflow.cluster.rpc.RpcEndpointRef.RpcCallback;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.common.heartbeat.Heartbeat;
 import com.antgroup.geaflow.common.utils.ExecutorUtil;
 import com.antgroup.geaflow.common.utils.ThreadUtil;
-import com.google.protobuf.Empty;
+import com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse;
 import java.io.Serializable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -38,15 +38,17 @@ public class HeartbeatSender implements Serializable {
     private final String masterId;
     private final ScheduledExecutorService scheduledService;
     private final Supplier<Heartbeat> heartbeatTrigger;
+    private final HeartbeatClient heartbeatClient;
     private final long initialDelayMs;
     private final long intervalMs;
 
     public HeartbeatSender(String masterId, Supplier<Heartbeat> heartbeatTrigger,
-                           Configuration config) {
+                           Configuration config, HeartbeatClient heartbeatClient) {
         this.masterId = masterId;
         this.heartbeatTrigger = heartbeatTrigger;
         this.scheduledService = new ScheduledThreadPoolExecutor(1,
             ThreadUtil.namedThreadFactory(true, "heartbeat-sender"));
+        this.heartbeatClient = heartbeatClient;
         this.initialDelayMs = config.getInteger(HEARTBEAT_INITIAL_DELAY_MS);
         this.intervalMs = config.getInteger(HEARTBEAT_INTERVAL_MS);
     }
@@ -57,10 +59,14 @@ public class HeartbeatSender implements Serializable {
             try {
                 message = heartbeatTrigger.get();
                 if (message != null) {
-                    RpcClient.getInstance().sendHeartBeat(masterId, message, new RpcEndpointRef.RpcCallback<Empty>() {
+                    RpcClient.getInstance().sendHeartBeat(masterId, message, new RpcCallback<HeartbeatResponse>() {
 
                         @Override
-                        public void onSuccess(Empty event) {
+                        public void onSuccess(HeartbeatResponse event) {
+                            if (!event.getRegistered()) {
+                                LOGGER.warn("Heartbeat is not registered.");
+                                heartbeatClient.registerToMaster();
+                            }
                         }
 
                         @Override

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/IMasterEndpointRef.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/IMasterEndpointRef.java
@@ -15,6 +15,7 @@
 package com.antgroup.geaflow.cluster.rpc;
 
 import com.antgroup.geaflow.common.heartbeat.Heartbeat;
+import com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterResponse;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
@@ -30,7 +31,7 @@ public interface IMasterEndpointRef extends Serializable {
     /**
      * Send heartbeat.
      */
-    ListenableFuture sendHeartBeat(Heartbeat request);
+    ListenableFuture<HeartbeatResponse> sendHeartBeat(Heartbeat heartbeat);
 
     /**
      * Send exception.

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcClient.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/RpcClient.java
@@ -48,6 +48,7 @@ import com.antgroup.geaflow.ha.service.ResourceData;
 import com.antgroup.geaflow.pipeline.IPipelineResult;
 import com.antgroup.geaflow.pipeline.Pipeline;
 import com.antgroup.geaflow.rpc.proto.Container.Response;
+import com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterResponse;
 import com.antgroup.geaflow.rpc.proto.Metrics.MetricQueryRequest;
 import com.antgroup.geaflow.rpc.proto.Metrics.MetricQueryResponse;
@@ -115,9 +116,9 @@ public class RpcClient implements Serializable {
         }, masterId, MASTER);
     }
 
-    public void sendHeartBeat(String masterId, Heartbeat heartbeat, RpcCallback<Empty> callback) {
+    public void sendHeartBeat(String masterId, Heartbeat heartbeat, RpcCallback<HeartbeatResponse> callback) {
         doRpcWithRetry(() -> {
-            ListenableFuture<Empty> future = connectMaster(masterId).sendHeartBeat(heartbeat);
+            ListenableFuture<HeartbeatResponse> future = connectMaster(masterId).sendHeartBeat(heartbeat);
             handleFutureCallback(future, callback, masterId);
         }, masterId, MASTER);
     }

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/MasterEndpoint.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/MasterEndpoint.java
@@ -23,6 +23,7 @@ import com.antgroup.geaflow.cluster.master.Master;
 import com.antgroup.geaflow.cluster.rpc.RpcEndpoint;
 import com.antgroup.geaflow.common.heartbeat.Heartbeat;
 import com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest;
+import com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterRequest;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterResponse;
 import com.antgroup.geaflow.rpc.proto.MasterServiceGrpc;
@@ -65,17 +66,17 @@ public class MasterEndpoint extends MasterServiceGrpc.MasterServiceImplBase impl
 
     @Override
     public void receiveHeartbeat(HeartbeatRequest request,
-                                 StreamObserver<Empty> responseObserver) {
+                                 StreamObserver<HeartbeatResponse> responseObserver) {
         try {
             Heartbeat heartbeat = new Heartbeat(request.getId());
             heartbeat.setTimestamp(request.getTimestamp());
             heartbeat.setContainerName(RpcMessageEncoder.decode(request.getName()));
             heartbeat.setProcessMetrics(RpcMessageEncoder.decode(request.getPayload()));
 
-            HeartbeatManager heartbeatManager = ((AbstractClusterManager) clusterManager)
-                .getClusterContext().getHeartbeatManager();
-            heartbeatManager.receivedHeartbeat(heartbeat);
-            responseObserver.onNext(Empty.newBuilder().build());
+            HeartbeatManager heartbeatManager =
+                ((AbstractClusterManager) clusterManager).getClusterContext().getHeartbeatManager();
+            HeartbeatResponse response = heartbeatManager.receivedHeartbeat(heartbeat);
+            responseObserver.onNext(response);
             responseObserver.onCompleted();
         } catch (Throwable t) {
             LOGGER.error("process {} heartbeat failed: {}", request.getId(), t.getMessage(), t);

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/MasterEndpointRef.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/main/java/com/antgroup/geaflow/cluster/rpc/impl/MasterEndpointRef.java
@@ -19,6 +19,7 @@ import com.antgroup.geaflow.cluster.rpc.IMasterEndpointRef;
 import com.antgroup.geaflow.common.config.Configuration;
 import com.antgroup.geaflow.common.heartbeat.Heartbeat;
 import com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest;
+import com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterRequest;
 import com.antgroup.geaflow.rpc.proto.Master.RegisterResponse;
 import com.antgroup.geaflow.rpc.proto.MasterServiceGrpc;
@@ -57,7 +58,7 @@ public class MasterEndpointRef extends AbstractRpcEndpointRef implements IMaster
     }
 
     @Override
-    public ListenableFuture<Empty> sendHeartBeat(Heartbeat heartbeat) {
+    public ListenableFuture<HeartbeatResponse> sendHeartBeat(Heartbeat heartbeat) {
         ensureChannelAlive();
         HeartbeatRequest heartbeatRequest = HeartbeatRequest.newBuilder()
             .setId(heartbeat.getContainerId())

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/java/com/antgroup/geaflow/cluster/rpc/RpcEndpointRefTest.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-cluster/src/test/java/com/antgroup/geaflow/cluster/rpc/RpcEndpointRefTest.java
@@ -25,11 +25,11 @@ import com.antgroup.geaflow.ha.service.HAServiceFactory;
 import com.antgroup.geaflow.ha.service.IHAService;
 import com.antgroup.geaflow.ha.service.ResourceData;
 import com.antgroup.geaflow.rpc.proto.Container;
+import com.antgroup.geaflow.rpc.proto.Master;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.protobuf.Empty;
 import io.grpc.StatusRuntimeException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -74,12 +74,12 @@ public class RpcEndpointRefTest {
 
         AtomicReference<String> msg = new AtomicReference<>();
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        ListenableFuture<Empty> future = masterEndpointRef.sendHeartBeat(new Heartbeat(1));
+        ListenableFuture<Master.HeartbeatResponse> future = masterEndpointRef.sendHeartBeat(new Heartbeat(1));
 
-        RpcClient.getInstance().handleFutureCallback(future, new RpcEndpointRef.RpcCallback<Empty>() {
+        RpcClient.getInstance().handleFutureCallback(future, new RpcEndpointRef.RpcCallback<Master.HeartbeatResponse>() {
 
             @Override
-            public void onSuccess(Empty event) {
+            public void onSuccess(Master.HeartbeatResponse event) {
                 LOGGER.info("on success");
                 msg.set("success");
                 countDownLatch.countDown();

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/java/com/antgroup/geaflow/rpc/proto/Master.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/java/com/antgroup/geaflow/rpc/proto/Master.java
@@ -2968,6 +2968,640 @@ public final class Master {
 
   }
 
+  public interface HeartbeatResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:HeartbeatResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>bool success = 1;</code>
+     * @return The success.
+     */
+    boolean getSuccess();
+
+    /**
+     * <code>bool registered = 2;</code>
+     * @return The registered.
+     */
+    boolean getRegistered();
+
+    /**
+     * <code>bytes payload = 3;</code>
+     * @return The payload.
+     */
+    com.google.protobuf.ByteString getPayload();
+  }
+  /**
+   * Protobuf type {@code HeartbeatResponse}
+   */
+  public static final class HeartbeatResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:HeartbeatResponse)
+      HeartbeatResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use HeartbeatResponse.newBuilder() to construct.
+    private HeartbeatResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private HeartbeatResponse() {
+      payload_ = com.google.protobuf.ByteString.EMPTY;
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new HeartbeatResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private HeartbeatResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+
+              success_ = input.readBool();
+              break;
+            }
+            case 16: {
+
+              registered_ = input.readBool();
+              break;
+            }
+            case 26: {
+
+              payload_ = input.readBytes();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.antgroup.geaflow.rpc.proto.Master.internal_static_HeartbeatResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.antgroup.geaflow.rpc.proto.Master.internal_static_HeartbeatResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.class, com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.Builder.class);
+    }
+
+    public static final int SUCCESS_FIELD_NUMBER = 1;
+    private boolean success_;
+    /**
+     * <code>bool success = 1;</code>
+     * @return The success.
+     */
+    @java.lang.Override
+    public boolean getSuccess() {
+      return success_;
+    }
+
+    public static final int REGISTERED_FIELD_NUMBER = 2;
+    private boolean registered_;
+    /**
+     * <code>bool registered = 2;</code>
+     * @return The registered.
+     */
+    @java.lang.Override
+    public boolean getRegistered() {
+      return registered_;
+    }
+
+    public static final int PAYLOAD_FIELD_NUMBER = 3;
+    private com.google.protobuf.ByteString payload_;
+    /**
+     * <code>bytes payload = 3;</code>
+     * @return The payload.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString getPayload() {
+      return payload_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (success_ != false) {
+        output.writeBool(1, success_);
+      }
+      if (registered_ != false) {
+        output.writeBool(2, registered_);
+      }
+      if (!payload_.isEmpty()) {
+        output.writeBytes(3, payload_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (success_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(1, success_);
+      }
+      if (registered_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(2, registered_);
+      }
+      if (!payload_.isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, payload_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse)) {
+        return super.equals(obj);
+      }
+      com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse other = (com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse) obj;
+
+      if (getSuccess()
+          != other.getSuccess()) return false;
+      if (getRegistered()
+          != other.getRegistered()) return false;
+      if (!getPayload()
+          .equals(other.getPayload())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + SUCCESS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getSuccess());
+      hash = (37 * hash) + REGISTERED_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getRegistered());
+      hash = (37 * hash) + PAYLOAD_FIELD_NUMBER;
+      hash = (53 * hash) + getPayload().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code HeartbeatResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:HeartbeatResponse)
+        com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.antgroup.geaflow.rpc.proto.Master.internal_static_HeartbeatResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.antgroup.geaflow.rpc.proto.Master.internal_static_HeartbeatResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.class, com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.Builder.class);
+      }
+
+      // Construct using com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        success_ = false;
+
+        registered_ = false;
+
+        payload_ = com.google.protobuf.ByteString.EMPTY;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.antgroup.geaflow.rpc.proto.Master.internal_static_HeartbeatResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse getDefaultInstanceForType() {
+        return com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse build() {
+        com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse buildPartial() {
+        com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse result = new com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse(this);
+        result.success_ = success_;
+        result.registered_ = registered_;
+        result.payload_ = payload_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse) {
+          return mergeFrom((com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse other) {
+        if (other == com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.getDefaultInstance()) return this;
+        if (other.getSuccess() != false) {
+          setSuccess(other.getSuccess());
+        }
+        if (other.getRegistered() != false) {
+          setRegistered(other.getRegistered());
+        }
+        if (other.getPayload() != com.google.protobuf.ByteString.EMPTY) {
+          setPayload(other.getPayload());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private boolean success_ ;
+      /**
+       * <code>bool success = 1;</code>
+       * @return The success.
+       */
+      @java.lang.Override
+      public boolean getSuccess() {
+        return success_;
+      }
+      /**
+       * <code>bool success = 1;</code>
+       * @param value The success to set.
+       * @return This builder for chaining.
+       */
+      public Builder setSuccess(boolean value) {
+        
+        success_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>bool success = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearSuccess() {
+        
+        success_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean registered_ ;
+      /**
+       * <code>bool registered = 2;</code>
+       * @return The registered.
+       */
+      @java.lang.Override
+      public boolean getRegistered() {
+        return registered_;
+      }
+      /**
+       * <code>bool registered = 2;</code>
+       * @param value The registered to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRegistered(boolean value) {
+        
+        registered_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>bool registered = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRegistered() {
+        
+        registered_ = false;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString payload_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>bytes payload = 3;</code>
+       * @return The payload.
+       */
+      @java.lang.Override
+      public com.google.protobuf.ByteString getPayload() {
+        return payload_;
+      }
+      /**
+       * <code>bytes payload = 3;</code>
+       * @param value The payload to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPayload(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        payload_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>bytes payload = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPayload() {
+        
+        payload_ = getDefaultInstance().getPayload();
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:HeartbeatResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:HeartbeatResponse)
+    private static final com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse();
+    }
+
+    public static com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<HeartbeatResponse>
+        PARSER = new com.google.protobuf.AbstractParser<HeartbeatResponse>() {
+      @java.lang.Override
+      public HeartbeatResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new HeartbeatResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<HeartbeatResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<HeartbeatResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_ContainerInfos_descriptor;
   private static final 
@@ -2993,6 +3627,11 @@ public final class Master {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_HeartbeatRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_HeartbeatResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_HeartbeatResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -3009,15 +3648,17 @@ public final class Master {
       "ver\030\002 \001(\010\"4\n\020RegisterResponse\022\017\n\007success" +
       "\030\001 \001(\010\022\017\n\007payload\030\002 \001(\014\"P\n\020HeartbeatRequ" +
       "est\022\n\n\002id\030\001 \001(\005\022\021\n\ttimestamp\030\002 \001(\003\022\017\n\007pa" +
-      "yload\030\003 \001(\014\022\014\n\004name\030\004 \001(\0142\210\002\n\rMasterServ" +
-      "ice\022:\n\021registerContainer\022\020.RegisterReque" +
-      "st\032\021.RegisterResponse\"\000\022?\n\020receiveHeartb" +
-      "eat\022\021.HeartbeatRequest\032\026.google.protobuf" +
-      ".Empty\"\000\022?\n\020receiveException\022\021.Heartbeat" +
-      "Request\032\026.google.protobuf.Empty\"\000\0229\n\005clo" +
-      "se\022\026.google.protobuf.Empty\032\026.google.prot" +
-      "obuf.Empty\"\000B\"\n\036com.antgroup.geaflow.rpc" +
-      ".protoP\000b\006proto3"
+      "yload\030\003 \001(\014\022\014\n\004name\030\004 \001(\014\"I\n\021HeartbeatRe" +
+      "sponse\022\017\n\007success\030\001 \001(\010\022\022\n\nregistered\030\002 " +
+      "\001(\010\022\017\n\007payload\030\003 \001(\0142\204\002\n\rMasterService\022:" +
+      "\n\021registerContainer\022\020.RegisterRequest\032\021." +
+      "RegisterResponse\"\000\022;\n\020receiveHeartbeat\022\021" +
+      ".HeartbeatRequest\032\022.HeartbeatResponse\"\000\022" +
+      "?\n\020receiveException\022\021.HeartbeatRequest\032\026" +
+      ".google.protobuf.Empty\"\000\0229\n\005close\022\026.goog" +
+      "le.protobuf.Empty\032\026.google.protobuf.Empt" +
+      "y\"\000B\"\n\036com.antgroup.geaflow.rpc.protoP\000b" +
+      "\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -3054,6 +3695,12 @@ public final class Master {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_HeartbeatRequest_descriptor,
         new java.lang.String[] { "Id", "Timestamp", "Payload", "Name", });
+    internal_static_HeartbeatResponse_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_HeartbeatResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_HeartbeatResponse_descriptor,
+        new java.lang.String[] { "Success", "Registered", "Payload", });
     com.google.protobuf.EmptyProto.getDescriptor();
   }
 

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/java/com/antgroup/geaflow/rpc/proto/MasterServiceGrpc.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/java/com/antgroup/geaflow/rpc/proto/MasterServiceGrpc.java
@@ -44,13 +44,13 @@ public class MasterServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(com.antgroup.geaflow.rpc.proto.Master.RegisterResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest,
-      com.google.protobuf.Empty> METHOD_RECEIVE_HEARTBEAT =
+      com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> METHOD_RECEIVE_HEARTBEAT =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "MasterService", "receiveHeartbeat"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest.getDefaultInstance()),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.Empty.getDefaultInstance()));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest,
       com.google.protobuf.Empty> METHOD_RECEIVE_EXCEPTION =
@@ -111,7 +111,7 @@ public class MasterServiceGrpc {
      * </pre>
      */
     public void receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver);
+        io.grpc.stub.StreamObserver<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> responseObserver);
 
     /**
      * <pre>
@@ -141,7 +141,7 @@ public class MasterServiceGrpc {
 
     @java.lang.Override
     public void receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+        io.grpc.stub.StreamObserver<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_RECEIVE_HEARTBEAT, responseObserver);
     }
 
@@ -178,7 +178,7 @@ public class MasterServiceGrpc {
      *处理executor/driver发送的心跳信息
      * </pre>
      */
-    public com.google.protobuf.Empty receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request);
+    public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request);
 
     /**
      * <pre>
@@ -212,7 +212,7 @@ public class MasterServiceGrpc {
      *处理executor/driver发送的心跳信息
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> receiveHeartbeat(
+    public com.google.common.util.concurrent.ListenableFuture<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> receiveHeartbeat(
         com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request);
 
     /**
@@ -258,7 +258,7 @@ public class MasterServiceGrpc {
 
     @java.lang.Override
     public void receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+        io.grpc.stub.StreamObserver<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_RECEIVE_HEARTBEAT, getCallOptions()), request, responseObserver);
     }
@@ -302,7 +302,7 @@ public class MasterServiceGrpc {
     }
 
     @java.lang.Override
-    public com.google.protobuf.Empty receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request) {
+    public com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse receiveHeartbeat(com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_RECEIVE_HEARTBEAT, getCallOptions(), request);
     }
@@ -345,7 +345,7 @@ public class MasterServiceGrpc {
     }
 
     @java.lang.Override
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> receiveHeartbeat(
+    public com.google.common.util.concurrent.ListenableFuture<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse> receiveHeartbeat(
         com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest request) {
       return futureUnaryCall(
           getChannel().newCall(METHOD_RECEIVE_HEARTBEAT, getCallOptions()), request);
@@ -396,7 +396,7 @@ public class MasterServiceGrpc {
           break;
         case METHODID_RECEIVE_HEARTBEAT:
           serviceImpl.receiveHeartbeat((com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
+              (io.grpc.stub.StreamObserver<com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse>) responseObserver);
           break;
         case METHODID_RECEIVE_EXCEPTION:
           serviceImpl.receiveException((com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest) request,
@@ -445,7 +445,7 @@ public class MasterServiceGrpc {
           asyncUnaryCall(
             new MethodHandlers<
               com.antgroup.geaflow.rpc.proto.Master.HeartbeatRequest,
-              com.google.protobuf.Empty>(
+              com.antgroup.geaflow.rpc.proto.Master.HeartbeatResponse>(
                 serviceImpl, METHODID_RECEIVE_HEARTBEAT)))
         .addMethod(
           METHOD_RECEIVE_EXCEPTION,

--- a/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/proto/master.proto
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-rpc-proto/src/main/proto/master.proto
@@ -12,7 +12,7 @@ service MasterService {
     }
 
     //处理executor/driver发送的心跳信息
-    rpc receiveHeartbeat(HeartbeatRequest) returns (google.protobuf.Empty) {
+    rpc receiveHeartbeat(HeartbeatRequest) returns (HeartbeatResponse) {
     }
 
     //处理executor/driver发送的异常信息
@@ -47,4 +47,10 @@ message HeartbeatRequest {
     int64 timestamp = 2;
     bytes payload = 3;
     bytes name = 4;
+}
+
+message HeartbeatResponse {
+    bool success = 1;
+    bool registered = 2;
+    bytes payload = 3;
 }

--- a/geaflow/geaflow-deploy/docker/Dockerfile
+++ b/geaflow/geaflow-deploy/docker/Dockerfile
@@ -22,6 +22,11 @@ ENV PATH=$JAVA_HOME/bin:${PATH}
 
 RUN mkdir -p /home/admin/logs
 
+# geaflow-engine-tar is the *.tar.gz file built by maven
+ARG geaflow_engine_tar=NOT_SET
+# Copy engine jar if exist
+ADD $geaflow_engine_tar $GEAFLOW_INSTALL_PATH
+
 WORKDIR $GEAFLOW_HOME
 
 COPY supervisord.conf /etc/supervisor/supervisord.conf

--- a/geaflow/geaflow-deploy/docker/Dockerfile-arm64
+++ b/geaflow/geaflow-deploy/docker/Dockerfile-arm64
@@ -21,6 +21,11 @@ ENV GEAFLOW_LIB_DIR=$GEAFLOW_HOME/lib \
     PATH=$PATH:$GEAFLOW_HOME/bin JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 ENV PATH=$JAVA_HOME/bin:${PATH}
 
+# geaflow-engine-tar is the *.tar.gz file built by maven
+ARG geaflow_engine_tar=NOT_SET
+# Copy engine jar if exist
+ADD $geaflow_engine_tar $GEAFLOW_INSTALL_PATH
+
 RUN mkdir -p /home/admin/logs
 
 WORKDIR $GEAFLOW_HOME

--- a/geaflow/geaflow-deploy/docker/start-process.sh
+++ b/geaflow/geaflow-deploy/docker/start-process.sh
@@ -56,8 +56,13 @@ function createDirIfNeed() {
 
 # 2. Download the engine jar package
 function downloadEngineJars() {
-  createDirIfNeed $GEAFLOW_LIB_DIR
-  su root -c "eval python /tmp/udf-downloader.py $BASE_LOG_PATH $GEAFLOW_LIB_DIR 'GEAFLOW_ENGINE_JAR' >> $BASE_LOG_PATH 2>&1"
+  JARS=$(find ${GEAFLOW_LIB_DIR} -type f -name "[!.]*.jar" 2>/dev/null)
+  if [[ -n ${JARS} ]]; then
+    echo "Default engine jar ${JARS} already exists, skip downloading engine jar."
+  else
+    createDirIfNeed $GEAFLOW_LIB_DIR
+    su root -c "eval python /tmp/udf-downloader.py $BASE_LOG_PATH $GEAFLOW_LIB_DIR 'GEAFLOW_ENGINE_JAR' >> $BASE_LOG_PATH 2>&1"
+  fi
 }
 
 # 3. Download the udf and extract the zip

--- a/geaflow/geaflow-deploy/geaflow-on-k8s/src/main/java/com/antgroup/geaflow/cluster/k8s/clustermanager/KubernetesResourceBuilder.java
+++ b/geaflow/geaflow-deploy/geaflow-on-k8s/src/main/java/com/antgroup/geaflow/cluster/k8s/clustermanager/KubernetesResourceBuilder.java
@@ -493,9 +493,8 @@ public class KubernetesResourceBuilder {
             metaBuilder.withOwnerReferences(ownerReference);
         }
         Map<String, String> serviceLabels = param.getServiceLabels();
-        if (serviceLabels != null) {
-            metaBuilder.withLabels(serviceLabels);
-        }
+        serviceLabels.putAll(labels);
+        metaBuilder.withLabels(serviceLabels);
         Map<String, String> serviceAnnotations = param.getServiceAnnotations();
         if (serviceAnnotations != null) {
             metaBuilder.withAnnotations(serviceAnnotations);


### PR DESCRIPTION
* Drivers and containers now check and register heartbeat after failover of master.
* Add labels for k8s services and deployments.

### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
