### PR TITLE
[ISSUE-326]Delete zookeeper directory

### DIFF
--- a/geaflow-console/app/core/service/src/main/java/com/antgroup/geaflow/console/core/service/statement/AnalyticsClientFactory.java
+++ b/geaflow-console/app/core/service/src/main/java/com/antgroup/geaflow/console/core/service/statement/AnalyticsClientFactory.java
@@ -39,7 +39,7 @@ public class AnalyticsClientFactory {
         configuration.putAll(task.getRelease().getJobConfig().toStringMap());
         configuration.put("brpc.connect.timeout.ms", String.valueOf(8000));
         configuration.put("geaflow.meta.server.retry.times", String.valueOf(2));
-        configuration.put("geaflow.job.unique.id", redisParentNamespace);
+        configuration.put("geaflow.job.runtime.name", redisParentNamespace);
         return builder.withConfiguration(configuration)
             .withInitChannelPools(true)
             .build();

--- a/geaflow-console/docker/bin/start-process.sh
+++ b/geaflow-console/docker/bin/start-process.sh
@@ -22,13 +22,11 @@ BASE_LOG_DIR=/tmp/logs
 GEAFLOW_LOG_DIR=$BASE_LOG_DIR/geaflow
 GEAFLOW_TASK_LOG_DIR=$BASE_LOG_DIR/task
 REDIS_LOG_DIR=$BASE_LOG_DIR/redis
-ZOOKEEPER_LOG_DIR=$BASE_LOG_DIR/zookeeper
 INFLUXDB_LOG_DIR=$BASE_LOG_DIR/influxdb
 mkdir -p $BASE_LOG_DIR
 mkdir -p $GEAFLOW_LOG_DIR
 mkdir -p $GEAFLOW_TASK_LOG_DIR
 mkdir -p $REDIS_LOG_DIR
-mkdir -p $ZOOKEEPER_LOG_DIR
 mkdir -p $INFLUXDB_LOG_DIR
 if [[ ! -L $GEAFLOW_HOME/logs ]]; then
   ln -s $BASE_LOG_DIR $GEAFLOW_HOME/logs
@@ -101,7 +99,7 @@ function startGeaflowConsole() {
   }
 }
 
-# start mysql, redis, zookeeper, influxdb
+# start mysql, redis, influxdb
 if [ "$DEPLOY_MODE" == "local" ]; then
   startMysql || exit 1
   startRedis || exit 1

--- a/geaflow/geaflow-examples/src/test/java/com/antgroup/geaflow/example/service/BaseServiceTest.java
+++ b/geaflow/geaflow-examples/src/test/java/com/antgroup/geaflow/example/service/BaseServiceTest.java
@@ -248,7 +248,7 @@ public class BaseServiceTest {
         defaultConfig = new Configuration();
         defaultConfig.put(RedisConfigKeys.REDIS_HOST, server.getHost());
         defaultConfig.put(RedisConfigKeys.REDIS_PORT, String.valueOf(server.getBindPort()));
-        defaultConfig.put(ExecutionConfigKeys.JOB_UNIQUE_ID, jobName);
+        defaultConfig.put(ExecutionConfigKeys.JOB_APP_NAME, jobName);
         metaServer = new MetaServer();
         metaServer.init(new MetaServerContext(defaultConfig));
     }

--- a/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/main/java/com/antgroup/geaflow/service/discovery/RedisServiceConsumer.java
+++ b/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/main/java/com/antgroup/geaflow/service/discovery/RedisServiceConsumer.java
@@ -19,8 +19,8 @@ public class RedisServiceConsumer implements ServiceConsumer {
 
     public RedisServiceConsumer(Configuration configuration) {
         this.recoverableRedis = new RecoverableRedis();
-        String jobUniqueId = configuration.getString(ExecutionConfigKeys.JOB_UNIQUE_ID);
-        this.baseKey = jobUniqueId.startsWith("/") ? jobUniqueId : "/" + jobUniqueId;
+        String appName = configuration.getString(ExecutionConfigKeys.JOB_APP_NAME);
+        this.baseKey = appName.startsWith("/") ? appName : "/" + appName;
         StoreContext storeContext = new StoreContext(baseKey);
         storeContext.withKeySerializer(new DefaultKVSerializer(String.class, null));
         storeContext.withConfig(configuration);

--- a/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/main/java/com/antgroup/geaflow/service/discovery/RedisServiceProvider.java
+++ b/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/main/java/com/antgroup/geaflow/service/discovery/RedisServiceProvider.java
@@ -16,8 +16,8 @@ public class RedisServiceProvider implements ServiceProvider {
 
     public RedisServiceProvider(Configuration configuration) {
         this.recoverableRedis = new RecoverableRedis();
-        String jobUniqueId = configuration.getString(ExecutionConfigKeys.JOB_UNIQUE_ID);
-        this.baseKey = jobUniqueId.startsWith("/") ? jobUniqueId : "/" + jobUniqueId;
+        String appName = configuration.getString(ExecutionConfigKeys.JOB_APP_NAME);
+        this.baseKey = appName.startsWith("/") ? appName : "/" + appName;
         StoreContext storeContext = new StoreContext(baseKey);
         storeContext.withKeySerializer(new DefaultKVSerializer(String.class, null));
         storeContext.withConfig(configuration);

--- a/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/test/java/com/antgroup/geaflow/service/discovery/RedisTest.java
+++ b/geaflow/geaflow-plugins/geaflow-service-discovery/geaflow-service-discovery-redis/src/test/java/com/antgroup/geaflow/service/discovery/RedisTest.java
@@ -32,7 +32,7 @@ public class RedisTest {
         this.configuration.put(RedisConfigKeys.REDIS_HOST, redisServer.getHost());
         this.configuration.put(RedisConfigKeys.REDIS_PORT, String.valueOf(redisServer.getBindPort()));
         this.configuration.put(SERVICE_DISCOVERY_TYPE, "redis");
-        this.configuration.put(ExecutionConfigKeys.JOB_UNIQUE_ID, "testJob123");
+        this.configuration.put(ExecutionConfigKeys.JOB_APP_NAME, "testJob123");
     }
 
     @AfterClass
@@ -110,7 +110,7 @@ public class RedisTest {
     public void testBaseKey() {
         Map<String, String> config = configuration.getConfigMap();
         Configuration newConfig = new Configuration(new HashMap<>(config));
-        newConfig.put(ExecutionConfigKeys.JOB_UNIQUE_ID, "234");
+        newConfig.put(ExecutionConfigKeys.JOB_APP_NAME, "234");
         this.consumer = ServiceBuilderFactory.build(serviceType).buildConsumer(newConfig);
         this.provider = ServiceBuilderFactory.build(serviceType).buildProvider(newConfig);
         Assert.assertTrue(provider.exists(null));


### PR DESCRIPTION
In the latest version, the meta service does not rely on zookeeper, so delete the Zookeeper-related directory.