### PR TITLE
 [ISSUE-375] Optimize the Quick Start documentation to allow users to experience it more quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ For GeaFlow design paper: [GeaFlow: A Graph Extended and Accelerated Dataflow Sy
 * Cloud-native deployment
 
 ## Quick start
-
+Step 1: Package the JAR and submit the Quick Start task
 1. Prepare Git、JDK8、Maven、Docker environment。
 2. Download Code：`git clone https://github.com/TuGraph-family/tugraph-analytics`
-3. Build Project：`./build.sh --module=gealfow --output=package` or `mvn clean install -DskipTests`
+3. Build Project：`./build.sh --module=gealfow --output=package`
 4. Test Job：`./bin/gql_submit.sh --gql geaflow/geaflow-examples/gql/loop_detection.sql`
-3. Build console JAR and image (requires starting Docker)：`./build.sh --module=gealfow-console`
-4. Start Console：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
+Step 2: Launch the console and experience submitting the Quick Start task through the console
+5. Build console JAR and image (requires starting Docker)：`./build.sh --module=gealfow-console`
+6. Start Console：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
 
 For more details：[Quick Start](docs/docs-cn/source/3.quick_start/1.quick_start.md)。
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ For GeaFlow design paper: [GeaFlow: A Graph Extended and Accelerated Dataflow Sy
 
 1. Prepare Git、JDK8、Maven、Docker environment。
 2. Download Code：`git clone https://github.com/TuGraph-family/tugraph-analytics`
-3. Build Project：`mvn clean install -DskipTests`
+3. Build Project：`./build.sh --module=gealfow --output=package` or `mvn clean install -DskipTests`
 4. Test Job：`./bin/gql_submit.sh --gql geaflow/geaflow-examples/gql/loop_detection.sql`
-3. Build Image：`./build.sh --all`
-4. Start Container：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
+3. Build console JAR and image (requires starting Docker)：`./build.sh --module=gealfow-console`
+4. Start Console：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
 
 For more details：[Quick Start](docs/docs-cn/source/3.quick_start/1.quick_start.md)。
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -38,10 +38,10 @@ GeaFlow设计论文参考：[GeaFlow: A Graph Extended and Accelerated Dataflow 
 
 1. 准备Git、JDK8、Maven、Docker环境。
 2. 下载源码：`git clone https://github.com/TuGraph-family/tugraph-analytics`
-3. 项目构建：`mvn clean install -DskipTests`
+3. 引擎构建：`./build.sh --module=gealfow --output=package` 或 `mvn clean install -DskipTests`
 4. 测试任务：`./bin/gql_submit.sh --gql geaflow/geaflow-examples/gql/loop_detection.sql`
-3. 构建镜像：`./build.sh --all`
-4. 启动容器：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
+3. 构建控制台jar和镜像(需启动Docker)：`./build.sh --module=gealfow-console`
+4. 启动控制台：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
 
 更多详细内容请参考：[快速上手文档](docs/docs-cn/source/3.quick_start/1.quick_start.md)。
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -35,13 +35,14 @@ GeaFlow设计论文参考：[GeaFlow: A Graph Extended and Accelerated Dataflow 
 * 云原生部署
 
 ## 快速上手
-
+第一步 打包jar包并提交quick start任务
 1. 准备Git、JDK8、Maven、Docker环境。
 2. 下载源码：`git clone https://github.com/TuGraph-family/tugraph-analytics`
-3. 引擎构建：`./build.sh --module=gealfow --output=package` 或 `mvn clean install -DskipTests`
+3. 引擎构建：`./build.sh --module=gealfow --output=package`
 4. 测试任务：`./bin/gql_submit.sh --gql geaflow/geaflow-examples/gql/loop_detection.sql`
-3. 构建控制台jar和镜像(需启动Docker)：`./build.sh --module=gealfow-console`
-4. 启动控制台：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
+第二步 启动控制台，体验白屏提交quick start任务
+5. 构建控制台jar和镜像(需启动Docker)：`./build.sh --module=gealfow-console`
+6. 启动控制台：`docker run -d --name geaflow-console -p 8888:8888 geaflow-console:0.1`
 
 更多详细内容请参考：[快速上手文档](docs/docs-cn/source/3.quick_start/1.quick_start.md)。
 

--- a/docs/docs-cn/source/3.quick_start/1.quick_start.md
+++ b/docs/docs-cn/source/3.quick_start/1.quick_start.md
@@ -15,7 +15,7 @@
 ```shell
 git clone https://github.com/TuGraph-family/tugraph-analytics.git
 cd tugraph-analytics/
-mvn clean package -DskipTests
+./build.sh --module=gealfow --output=package
 ```
 
 ## 本地运行流图作业

--- a/docs/docs-cn/source/3.quick_start/2.quick_start_docker.md
+++ b/docs/docs-cn/source/3.quick_start/2.quick_start_docker.md
@@ -11,12 +11,12 @@
 
 x86架构拉取x86镜像：
 ```shell
-docker pull tugraph/geaflow-console:0.1
+docker pull tugraph/geaflow-console:<version>
 ```
 
 如果是arm架构，拉取arm镜像：
 ```shell
-docker pull tugraph/geaflow-console-arm:0.1
+docker pull tugraph/geaflow-console-arm:<version>
 ```
 
 如果遇到网络问题导致拉取失败，也可以通过下面命令直接构建镜像(构建镜像之前需要先启动docker容器,构建脚本根据机器类型build对应类型的镜像):
@@ -25,7 +25,7 @@ docker pull tugraph/geaflow-console-arm:0.1
 ```shell
 git clone https://github.com/TuGraph-family/tugraph-analytics.git
 cd tugraph-analytics/
-bash ./build.sh --all
+./build.sh --module=gealfow-console
 
 ```
 

--- a/docs/docs-en/source/3.quick_start/1.quick_start.md
+++ b/docs/docs-en/source/3.quick_start/1.quick_start.md
@@ -10,7 +10,7 @@ Execute the following commands to compile the GeaFlow source code:
 ```shell
 git clone https://github.com/TuGraph-family/tugraph-analytics.git
 cd tugraph-analytics/
-mvn clean package -DskipTests
+./build.sh --module=gealfow --output=package
 ```
 
 ## Running Job In Local

--- a/docs/docs-en/source/3.quick_start/2.quick_start_docker.md
+++ b/docs/docs-en/source/3.quick_start/2.quick_start_docker.md
@@ -10,12 +10,12 @@ Run the following command to pull the remote geaflow console image:
 
 For x86 architecture pull x86 image:
 ```shell
-docker pull tugraph/geaflow-console:0.1
+docker pull tugraph/geaflow-console:<version>
 ```
 
 If it is arm architecture, pull the arm image:
 ```shell
-docker pull tugraph/geaflow-console-arm:0.1
+docker pull tugraph/geaflow-console-arm:<version>
 ```
 
 If the pull fails due to network problems, you can also run the following command to directly build the local image 
@@ -25,7 +25,7 @@ corresponding type based on the machine type):
 ```shell
 git clone https://github.com/TuGraph-family/tugraph-analytics.git
 cd tugraph-analytics/
-bash ./build.sh --all
+./build.sh --module=gealfow-console
 
 ```
 


### PR DESCRIPTION
Optimize the Quick Start documentation to allow users to experience it more quickly #375 

According to the current Quick Start guide, users need to build the entire engine and console images to experience the demo case, which is time-consuming. To help users experience the Quick Start demo more quickly, the documentation should be optimized to specify that, when running demos that only rely on the engine JAR package, users only need to package the engine without building images. When running demos that rely on both the console image and the JAR package, users only need to build both.