### PR TITLE
Fix LICENSE copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 AntGroup CO., Ltd.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION

### What changes were proposed in this pull request?
Minor change. The appendix is an example of how to apply the license to a file and should not have a specific copyright line.

### How was this PR tested?
N/A