### PR TITLE
[Runtime] Fix checkpoint causing empty results in PipelineServiceExecutorContext (#543)

### DIFF
--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-pipeline/src/main/java/com/antgroup/geaflow/runtime/pipeline/runner/PipelineRunner.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-pipeline/src/main/java/com/antgroup/geaflow/runtime/pipeline/runner/PipelineRunner.java
@@ -106,11 +106,13 @@ public class PipelineRunner {
 
             Map<Integer, List<ExecutionTask>> vertex2Tasks = ExecutionCycleTaskAssigner.assign(graph);
 
+            // Skip checkpoint if it's a PipelineServiceExecutorContext
+            boolean skipCheckpoint = pipelineExecutorContext instanceof PipelineServiceExecutorContext;
             IExecutionCycle cycle = ExecutionCycleBuilder.buildExecutionCycle(graph, vertex2Tasks,
                 pipelineContext.getConfig(), ExecutionIdGenerator.getInstance().generateId(),
                 pipelineExecutorContext.getPipelineTaskId(), pipelineExecutorContext.getPipelineTaskName(),
                 ExecutionIdGenerator.getInstance().generateId(), pipelineExecutorContext.getDriverId(),
-                pipelineExecutorContext.getDriverIndex());
+                pipelineExecutorContext.getDriverIndex(), skipCheckpoint);
             return CycleSchedulerContextFactory.create(cycle, null);
         });
         return context;

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionCycleBuilder.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionCycleBuilder.java
@@ -45,7 +45,8 @@ public class ExecutionCycleBuilder {
                                                       String name,
                                                       long schedulerId,
                                                       String driverId,
-                                                      int driverIndex) {
+                                                      int driverIndex,
+                                                      boolean skipCheckpoint) {
 
         int flyingCount = executionGraph.getCycleGroupMeta().getFlyingCount();
         long iterationCount = executionGraph.getCycleGroupMeta().getIterationCount();
@@ -54,7 +55,7 @@ public class ExecutionCycleBuilder {
         for (ExecutionVertexGroup vertexGroup : executionGraph.getVertexGroupMap().values()) {
             ExecutionNodeCycle nodeCycle = buildExecutionCycle(vertexGroup,
                 vertex2Tasks, config, pipelineId, pipelineTaskId, name, schedulerId, driverId, driverIndex);
-            graphCycle.addCycle(nodeCycle);
+            graphCycle.addCycle(nodeCycle, skipCheckpoint);
         }
         return graphCycle;
     }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionGraphCycle.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/main/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionGraphCycle.java
@@ -68,7 +68,7 @@ public class ExecutionGraphCycle extends AbstractExecutionCycle {
         return haLevel;
     }
 
-    public void addCycle(IExecutionCycle cycle) {
+    public void addCycle(IExecutionCycle cycle, boolean skipCheckpoint) {
         if (cycleMap.containsKey(cycle.getCycleId())) {
             throw new GeaflowRuntimeException(String.format("cycle %d already added", cycle.getCycleId()));
         }
@@ -80,8 +80,8 @@ public class ExecutionGraphCycle extends AbstractExecutionCycle {
         cycleParents.get(cycle.getCycleId()).addAll(nodeCycle.getVertexGroup().getParentVertexGroupIds());
         cycleChildren.get(cycle.getCycleId()).addAll(nodeCycle.getVertexGroup().getChildrenVertexGroupIds());
 
-        if (iterationCount > 1 && haLevel != HighAvailableLevel.CHECKPOINT
-            && (cycle.getType() == ExecutionCycleType.ITERATION || cycle.getType() == ExecutionCycleType.ITERATION_WITH_AGG)) {
+        if (!skipCheckpoint && (iterationCount > 1 && haLevel != HighAvailableLevel.CHECKPOINT
+            && (cycle.getType() == ExecutionCycleType.ITERATION || cycle.getType() == ExecutionCycleType.ITERATION_WITH_AGG))) {
             haLevel = HighAvailableLevel.CHECKPOINT;
         }
     }

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleSchedulerTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/ExecutionGraphCycleSchedulerTest.java
@@ -206,7 +206,7 @@ public class ExecutionGraphCycleSchedulerTest extends BaseCycleSchedulerTest {
             1, 10, configuration, "driver_id", 0);
         ExecutionNodeCycle nodeCycle = buildMockIterationNodeCycle(configuration);
 
-        graphCycle.addCycle(nodeCycle);
+        graphCycle.addCycle(nodeCycle, false);
         try {
             ReflectionUtil.setField(graphCycle, "haLevel", CHECKPOINT);
         } catch (Exception e) {

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/context/ExecutionGraphCycleSchedulerContextTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/context/ExecutionGraphCycleSchedulerContextTest.java
@@ -40,7 +40,7 @@ public class ExecutionGraphCycleSchedulerContextTest extends BaseCycleSchedulerC
         parentContext.init(1);
 
         ExecutionNodeCycle iterationCycle = buildPipelineCycle(false, finishIterationId);
-        graph.addCycle(iterationCycle);
+        graph.addCycle(iterationCycle, false);
         CheckpointSchedulerContext iterationContext = new CheckpointSchedulerContext(iterationCycle, parentContext);
         iterationContext.init();
 

--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionCycleBuilderTest.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-runtime-core/src/test/java/com/antgroup/geaflow/runtime/core/scheduler/cycle/ExecutionCycleBuilderTest.java
@@ -35,7 +35,7 @@ public class ExecutionCycleBuilderTest {
         meta.setFlyingCount(0);
         meta.setGroupType(CycleGroupType.windowed);
 
-        ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0, null, 0,null, 0);
+        ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0, null, 0,null, 0, false);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
@@ -45,7 +45,7 @@ public class ExecutionCycleBuilderTest {
         CycleGroupMeta meta = executionGraph.getCycleGroupMeta();
         meta.setIterationCount(0);
         meta.setGroupType(CycleGroupType.windowed);
-        ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0, null, 0, null, 0);
+        ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0, null, 0, null, 0, false);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
@@ -62,7 +62,7 @@ public class ExecutionCycleBuilderTest {
         executionGraph.getVertexGroupMap().put(1, vertexGroup);
 
         ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0,  null, 0, null,
-            0);
+            0, false);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
@@ -79,6 +79,6 @@ public class ExecutionCycleBuilderTest {
         executionGraph.getVertexGroupMap().put(1, vertexGroup);
 
         ExecutionCycleBuilder.buildExecutionCycle(executionGraph, null, null, 0, 0,  null, 0, null,
-            0);
+            0, false);
     }
 }


### PR DESCRIPTION
* fix checkpoint causing empty results in interactive query
* skip checkpoint when context is PipelineServiceExecutorContext

### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->

### How was this PR tested?
- [ ] Production environment verified
refer to https://github.com/TuGraph-family/tugraph-analytics/issues/543
Create a graph query type task with the graph name 'dy_modern' selected,

STEP1:
start the task and execute following gql:
"""
MATCH (a:person) -[e ]->(b)
Let a.out_cnt = COUNT((b) ->(c) => c),
Let b.out_weight = SUM((b) -[e1]-> (c) => e1.weight)
RETURN a,e,b
"""
You can see that the query results is not empty

STEP2:
execute
"""
WITH p AS (
SELECT * FROM (VALUES(1, 0.4), (4, 0.5)) AS t(id, weight)
)
MATCH (a:person where a.id = p.id) -[e where weight < p.weight + 0.1]->(b)
Let a.out_cnt = COUNT((b) ->(c) => c),
Let b.out_weight = SUM((b) -[e1]-> (c) => e1.weight)
RETURN a,e,b
"""
You can also see that the query results is not empty

STEP3:
execute gsql the same as step1 or step2
"""
MATCH (a:person) -[e ]->(b)
Let a.out_cnt = COUNT((b) ->(c) => c),
Let b.out_weight = SUM((b) -[e1]-> (c) => e1.weight)
RETURN a,e,b
"""
Before： 
the results is empty

After integrating repair PR：
consistent with the previous query results


