### PR TITLE
fix(shuffle): prevent NPE in SpillablePipelineSlice.hasNext() during concurrent release (#551)

### DIFF
--- a/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/pipeline/slice/SpillablePipelineSlice.java
+++ b/geaflow/geaflow-core/geaflow-engine/geaflow-shuffle/src/main/java/com/antgroup/geaflow/shuffle/pipeline/slice/SpillablePipelineSlice.java
@@ -213,7 +213,6 @@ public class SpillablePipelineSlice extends AbstractSlice {
             return;
         }
         this.buffers.clear();
-        this.buffers = null;
         try {
             if (streamBufferIterator != null) {
                 streamBufferIterator.close();


### PR DESCRIPTION
reference: https://github.com/TuGraph-family/tugraph-analytics/issues/551 

This PR fixes a NullPointerException (NPE) in SpillablePipelineSlice.hasNext() that occurs when slices are released concurrently from different paths (e.g., PipelineSliceReader and SliceManager).

### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->
1. Remove buffers=null in SpillablePipelineSlice.release()

### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
