### PR TITLE
Fix cast issue

### DIFF
--- a/geaflow/geaflow-core/geaflow-runtime/geaflow-pipeline/src/main/java/org/apache/geaflow/runtime/pipeline/runner/PipelineRunner.java
+++ b/geaflow/geaflow-core/geaflow-runtime/geaflow-pipeline/src/main/java/org/apache/geaflow/runtime/pipeline/runner/PipelineRunner.java
@@ -68,8 +68,9 @@ public class PipelineRunner {
         }
 
         ICycleScheduler scheduler = CycleSchedulerFactory.create(context.getCycle());
+        long schedulerId = context.getCycle().getSchedulerId();
         if (scheduler instanceof IEventListener) {
-            eventDispatcher.registerListener(context.getCycle().getSchedulerId(), (IEventListener) scheduler);
+            eventDispatcher.registerListener(schedulerId, (IEventListener) scheduler);
         }
 
         scheduler.init(context);
@@ -77,7 +78,7 @@ public class PipelineRunner {
         LOGGER.info("final result of pipeline is {}", result.getResult());
         scheduler.close();
         if (scheduler instanceof IEventListener) {
-            eventDispatcher.removeListener(((ExecutionGraphCycleScheduler) scheduler).getSchedulerId());
+            eventDispatcher.removeListener(schedulerId);
         }
         return result;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

I simulated the automatic failover capability of the container module by randomly killing threads inside the container and discovered that the driver module has an infinite crash issue. The crash stack is as follows:

```
2025-09-24 15:02:22,569 [driver-executor-0] ERROR Driver:154  - driver exception
java.lang.ClassCastException: org.apache.geaflow.runtime.core.scheduler.PipelineCycleScheduler cannot be cast to org.apache.geaflow.runtime.core.scheduler.ExecutionGraphCycleScheduler
	at org.apache.geaflow.runtime.pipeline.runner.PipelineRunner.executePipelineGraph(PipelineRunner.java:80)
	at org.apache.geaflow.runtime.pipeline.runner.PipelineRunner.runPipelineGraph(PipelineRunner.java:87)
	at org.apache.geaflow.runtime.pipeline.task.PipelineTaskExecutor.execute(PipelineTaskExecutor.java:54)
	at org.apache.geaflow.runtime.pipeline.executor.PipelineExecutor.runPipelineTask(PipelineExecutor.java:76)
	at org.apache.geaflow.cluster.driver.Driver.executePipelineInternal(Driver.java:136)
	at org.apache.geaflow.cluster.driver.Driver.lambda$init$0(Driver.java:92)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

The reason for the issue is that `CycleSchedulerFactory.create()` may return either a `PipelineCycleScheduler` type or an `ExecutionGraphCycleScheduler` type, but the [code](https://github.com/apache/geaflow/blob/817bdd9306b77d83e0bf475c6dbf0f8d28494589/geaflow/geaflow-core/geaflow-runtime/geaflow-pipeline/src/main/java/org/apache/geaflow/runtime/pipeline/runner/PipelineRunner.java#L80) only accounts for the `ExecutionGraphCycleScheduler` scenario.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [x] Production environment verified
