### PR TITLE
Modify the value of the DOCKER_FILE attribute in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ done
 ARCH=$(uname -m)
 if [[ "$ARCH" = "x86_64" ]]; then
   if [[ "$USE_UBUNTU" = "true" ]]; then
-    DOCKER_FILE="Dockerfile-ubuntu"
+    DOCKER_FILE="Dockerfile-ubuntu-centos"
   else
     DOCKER_FILE="Dockerfile-centos"
   fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->

When compiling the geaflow-console directory through build.sh, there are only dockerfile-ubuntu-centos files but no Dockerfile-ubuntu files.

### How was this PR tested?
- [x] Tests have Added for the changes
- [ ] Production environment verified
if [[ "$ARCH" = "x86_64" ]]; then
  if [[ "$USE_UBUNTU" = "true" ]]; then
   DOCKER_FILE="Dockerfile-ubuntu-centos"
 else
    DOCKER_FILE="Dockerfile-centos"