### PR TITLE
Fix memory management in mmap_ipc.cpp

### DIFF
--- a/geaflow/geaflow-infer/src/main/resources/infer/inferRuntime/mmap_ipc.cpp
+++ b/geaflow/geaflow-infer/src/main/resources/infer/inferRuntime/mmap_ipc.cpp
@@ -6586,7 +6586,6 @@ __Pyx_CyFunction_get_is_coroutine(__pyx_CyFunctionObject *op, void *context) {
         PyList_SET_ITEM(fromlist, 0, marker);
 #else
         if (unlikely(PyList_SetItem(fromlist, 0, marker) < 0)) {
-            Py_DECREF(marker);
             Py_DECREF(fromlist);
             return NULL;
         }


### PR DESCRIPTION
Remove incorrect Py_DECREF call for marker.

### Related Code

https://github.com/apache/geaflow/blob/f891ede132df65026ff71aa43f83a12dcfdbecdd/geaflow/geaflow-infer/src/main/resources/infer/inferRuntime/mmap_ipc.cpp#L6587-L6589

[PyList_SetItem Source Code](https://github.com/python/cpython/blob/a126893fa80c4ee5f0bac8a84a49491c19edd511/Objects/listobject.c#L454)

[PyList_SetItem Document](https://docs.python.org/3/c-api/list.html#c.PyList_SetItem)

[PyList_SetItem Python Forum Discussion](https://discuss.python.org/t/proper-handling-of-pylist-setitem-return-value-and-reference-stealing-in-cpython-c-extensions/105805)

Therefore, whether the function succeeds or fails, it will steal a reference count of the third argument. It must not call `Py_DECREF` in case of failure.



### How was this PR tested?
- [ ] Tests have Added for the changes
- [ ] Production environment verified
