### PR TITLE
fix:Add check for empty search results to prevent array out of bounds

### DIFF
--- a/geaflow/geaflow-plugins/geaflow-store/geaflow-store-vector/src/main/java/org/apache/geaflow/store/lucene/GraphVectorIndex.java
+++ b/geaflow/geaflow-plugins/geaflow-store/geaflow-store-vector/src/main/java/org/apache/geaflow/store/lucene/GraphVectorIndex.java
@@ -145,8 +145,10 @@ public class GraphVectorIndex<K> implements IVectorIndex<K> {
             // Execute search
             TopDocs topDocs = searcher.search(knnQuery, topK);
 
+            if (topDocs.scoreDocs.length == 0) {
+                return null;
+            }
             Document firstDoc = searcher.storedFields().document(topDocs.scoreDocs[0].doc);
-
             K result;
             if (keyClass == String.class) {
                 String value = firstDoc.get(KEY_FIELD_NAME);

--- a/geaflow/geaflow-plugins/geaflow-store/geaflow-store-vector/src/test/java/org/apache/geaflow/store/lucene/GraphVectorIndexTest.java
+++ b/geaflow/geaflow-plugins/geaflow-store/geaflow-store-vector/src/test/java/org/apache/geaflow/store/lucene/GraphVectorIndexTest.java
@@ -155,4 +155,11 @@ public class GraphVectorIndexTest {
         assertEquals(result1, key);
         assertEquals(result2, key);
     }
+    @Test
+    public void testSearchNonExistentFieldReturnsNull() {
+        stringIndex.addVectorIndex(true, "vertex_1", "embedding", new float[]{0.1f, 0.2f, 0.3f, 0.4f});
+        // searching for a non-existent field should return null
+        String result = stringIndex.searchVectorIndex(true, "nonexistent_field", new float[]{0.1f, 0.2f, 0.3f, 0.4f}, 1);
+        assertEquals(result, null);
+    }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--Please describe the major changes for this PR-->

Directly accessing index 0 carries a risk.
It is better to check that the length is greater than zero in advance.

```java
Document firstDoc = searcher.doc(topDocs.scoreDocs[0].doc);
```

### How was this PR tested?
- [x] Tests have Added for the changes
- [ ] Production environment verified
